### PR TITLE
fix run_pureGAM function parameters; add demo for pureGAM run & interpret

### DIFF
--- a/XAI/pureGAM/run_puregam_demo.ipynb
+++ b/XAI/pureGAM/run_puregam_demo.ipynb
@@ -1,0 +1,424 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.preprocessing import MinMaxScaler\n",
+    "import torch\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "from experiments.run_experiment_realdata import run_pureGam\n",
+    "from torch_utils.dataset_util import PureGamDataset, PureGamDataset_smoothingInTraining\n",
+    "device = torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "load data from :: ./realdata/airfoil.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "# todo: airfoil\n",
+    "seed = 1234\n",
+    "base_dir = \"./\"\n",
+    "dataset_name = \"airfoil\"\n",
+    "# dataset_name = \"flat_dirichlet_generate\"\n",
+    "model_output_dir = \"../model_save/realdata/\" + dataset_name + \"/\"\n",
+    "base_results_folder = results_folder = 'results_' + str(seed) + '/' + dataset_name\n",
+    "\n",
+    "# Load Data from dataset\n",
+    "df = pd.read_csv(base_dir + \"realdata/\" + dataset_name + \".csv\")\n",
+    "print(\"load data from ::\", base_dir + \"realdata/\" + dataset_name + \".csv\")\n",
+    "\n",
+    "# \"HoursPerWeek\",\"TotalHours\", carry ?\"Age\",\"APM\"\n",
+    "\n",
+    "X_num = df.loc[:, [\"in1\", \"in2\", \"in3\", \"in4\", \"in5\"]].values\n",
+    "X_cate = df.loc[:, []].values\n",
+    "# \"L3\",\"L4\",\"L5\"\n",
+    "y = df.loc[:, [\"out\"]].values\n",
+    "sy = MinMaxScaler((0, 1))\n",
+    "y = sy.fit_transform(y)\n",
+    "# run_pureGam_gami_kfold(X_num, X_cate, y, base_results_folder, seed=seed)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "&&&& Device USED :: cuda:0\n",
+      "Full Interaction [[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]\n",
+      "Full Interaction []\n",
+      "{*} Model Size 10286\n",
+      "Param:: tensor([[5.0000e+02, 6.7000e+00, 1.0160e-01, 3.9600e+01, 5.7808e-03],\n",
+      "        [8.0000e+03, 4.8000e+00, 2.5400e-02, 3.1700e+01, 9.3079e-04],\n",
+      "        [8.0000e+03, 1.5000e+00, 3.0480e-01, 7.1300e+01, 3.3673e-03],\n",
+      "        [3.1500e+03, 1.7400e+01, 2.5400e-02, 3.1700e+01, 1.7663e-02],\n",
+      "        [6.3000e+03, 1.0000e-12, 5.0800e-02, 3.9600e+01, 7.9182e-04],\n",
+      "        [1.0000e+03, 1.0000e-12, 1.5240e-01, 3.1700e+01, 2.0941e-03],\n",
+      "        [1.6000e+03, 1.0000e-12, 5.0800e-02, 3.9600e+01, 7.9182e-04],\n",
+      "        [1.6000e+03, 1.0000e-12, 5.0800e-02, 7.1300e+01, 7.4048e-04],\n",
+      "        [8.0000e+03, 1.0000e-12, 1.0160e-01, 3.1700e+01, 1.5009e-03],\n",
+      "        [5.0000e+03, 8.9000e+00, 1.0160e-01, 7.1300e+01, 1.0309e-02]],\n",
+      "       device='cuda:0', dtype=torch.float64, grad_fn=<SliceBackward0>) tensor([[1.2500e+03, 7.3000e+00, 2.2860e-01, 7.1300e+01, 1.0440e-02],\n",
+      "        [6.3000e+03, 1.5000e+00, 3.0480e-01, 3.9600e+01, 3.9211e-03],\n",
+      "        [5.0000e+03, 1.5000e+00, 3.0480e-01, 7.1300e+01, 3.3673e-03],\n",
+      "        [3.1500e+03, 8.4000e+00, 5.0800e-02, 3.9600e+01, 5.6623e-03],\n",
+      "        [1.2500e+03, 1.5600e+01, 1.0160e-01, 3.9600e+01, 5.2849e-02],\n",
+      "        [4.0000e+03, 7.3000e+00, 2.2860e-01, 7.1300e+01, 1.0440e-02],\n",
+      "        [2.0000e+03, 4.8000e+00, 2.5400e-02, 7.1300e+01, 8.4863e-04],\n",
+      "        [1.0000e+04, 1.0000e-12, 5.0800e-02, 3.1700e+01, 8.1216e-04],\n",
+      "        [6.3000e+03, 9.9000e+00, 1.5240e-01, 3.1700e+01, 2.5279e-02],\n",
+      "        [3.1500e+03, 1.2300e+01, 1.0160e-01, 7.1300e+01, 3.3779e-02]],\n",
+      "       device='cuda:0', dtype=torch.float64, grad_fn=<SliceBackward0>)\n",
+      "time :  20.213742971420288\n",
+      "Epoch 86  is ::: \n",
+      "     train: [0.01828 0.      0.      0.00111] 0.0194\n",
+      "          [ 4.5598e-01  1.6000e-03 -1.3000e-04  3.5300e-03  2.5380e-02]\n",
+      "     valid: [0.02414 0.      0.      0.00038] 0.02452\n",
+      "          [ 0.29203  0.00123 -0.00036  0.00232  0.01673]\n",
+      "time :  20.093989372253418\n",
+      "Epoch 179  is ::: \n",
+      "     train: [0.01508 0.      0.      0.00087] 0.01596\n",
+      "          [ 0.55112  0.00189 -0.00073  0.00293  0.0266 ]\n",
+      "     valid: [0.0218  0.      0.      0.00041] 0.02221\n",
+      "          [ 3.605e-01  1.410e-03 -2.000e-04  2.100e-03  3.300e-02]\n",
+      "time :  20.15875744819641\n",
+      "Epoch 253  is ::: \n",
+      "     train: [0.01314 0.      0.      0.00076] 0.0139\n",
+      "          [ 6.0903e-01  2.4100e-03 -2.9000e-04  2.8700e-03  2.6360e-02]\n",
+      "     valid: [0.01841 0.      0.      0.00049] 0.0189\n",
+      "          [ 4.6001e-01  2.0400e-03 -1.5000e-04  2.2700e-03  4.1870e-02]\n",
+      "time :  20.01267433166504\n",
+      "Epoch 332  is ::: \n",
+      "     train: [0.00999 0.      0.      0.00098] 0.01098\n",
+      "          [ 7.0263e-01  2.5000e-03 -1.8000e-04  3.2900e-03  3.0320e-02]\n",
+      "     valid: [0.01553 0.      0.      0.00059] 0.01612\n",
+      "          [ 5.4437e-01  2.3700e-03 -2.3000e-04  2.5300e-03  4.5060e-02]\n",
+      "time :  20.15038514137268\n",
+      "Epoch 409  is ::: \n",
+      "     train: [0.00896 0.      0.      0.00079] 0.00975\n",
+      "          [ 0.7335   0.00263 -0.00137  0.00302  0.03726]\n",
+      "     valid: [0.01307 0.      0.      0.0006 ] 0.01367\n",
+      "          [ 6.1677e-01  2.3700e-03 -5.8000e-04  2.4700e-03  4.6630e-02]\n",
+      "time :  20.104432821273804\n",
+      "Epoch 492  is ::: \n",
+      "     train: [0.00638 0.      0.      0.00102] 0.0074\n",
+      "          [ 8.1015e-01  9.1000e-04 -4.8000e-04  3.0600e-03  3.2160e-02]\n",
+      "     valid: [0.01192 0.      0.      0.00068] 0.01261\n",
+      "          [ 6.5023e-01  2.2700e-03 -5.9000e-04  2.5400e-03  4.7070e-02]\n",
+      "time :  20.040822744369507\n",
+      "Epoch 581  is ::: \n",
+      "     train: [6.32e-03 1.00e-05 0.00e+00 9.10e-04] 0.00724\n",
+      "          [8.1188e-01 3.4000e-04 3.6000e-04 2.8300e-03 3.5540e-02]\n",
+      "     valid: [0.01107 0.      0.      0.00072] 0.01179\n",
+      "          [ 6.7538e-01  2.2400e-03 -5.2000e-04  2.5500e-03  4.8160e-02]\n",
+      "time :  20.159998416900635\n",
+      "Epoch 664  is ::: \n",
+      "     train: [0.00565 0.      0.      0.00111] 0.00676\n",
+      "          [ 8.3194e-01  5.9000e-04 -2.9000e-04  2.9000e-03  3.7670e-02]\n",
+      "     valid: [0.01062 0.      0.      0.00077] 0.0114\n",
+      "          [ 6.8855e-01  2.2400e-03 -4.9000e-04  2.6200e-03  4.8770e-02]\n",
+      "time :  20.170021295547485\n",
+      "Epoch 753  is ::: \n",
+      "     train: [0.0055  0.      0.      0.00068] 0.00619\n",
+      "          [ 8.3622e-01  8.1000e-04 -4.1000e-04  2.3900e-03  4.0960e-02]\n",
+      "     valid: [0.01029 0.      0.      0.0008 ] 0.0111\n",
+      "          [ 6.9804e-01  1.9000e-03 -6.2000e-04  2.5800e-03  4.7410e-02]\n",
+      "time :  20.2199923992157\n",
+      "Epoch 833  is ::: \n",
+      "     train: [0.00477 0.      0.      0.00089] 0.00567\n",
+      "          [ 8.5812e-01 -8.9000e-04  1.0000e-04  2.5900e-03  4.5940e-02]\n",
+      "     valid: [0.00998 0.      0.      0.00086] 0.01085\n",
+      "          [ 7.0721e-01  1.8300e-03 -5.3000e-04  2.5900e-03  4.9470e-02]\n",
+      "time :  20.16709017753601\n",
+      "Epoch 910  is ::: \n",
+      "     train: [0.00592 0.      0.      0.00079] 0.00671\n",
+      "          [ 8.2388e-01  1.1000e-04 -1.9000e-04  2.3600e-03  3.6270e-02]\n",
+      "     valid: [0.00948 0.      0.      0.00087] 0.01036\n",
+      "          [ 7.2185e-01  1.6200e-03 -5.9000e-04  2.5600e-03  4.8580e-02]\n",
+      "time :  20.060662269592285\n",
+      "Epoch 1004  is ::: \n",
+      "     train: [0.00459 0.      0.      0.00094] 0.00554\n",
+      "          [ 8.633e-01  1.990e-03 -3.200e-04  2.880e-03  4.007e-02]\n",
+      "     valid: [0.00866 0.      0.      0.00087] 0.00953\n",
+      "          [ 7.4612e-01  1.4600e-03 -5.7000e-04  2.7300e-03  4.5960e-02]\n",
+      "time :  20.151253938674927\n",
+      "Epoch 1087  is ::: \n",
+      "     train: [3.88e-03 1.00e-05 0.00e+00 7.00e-04] 0.0046\n",
+      "          [ 8.844e-01  3.400e-04 -4.200e-04  2.410e-03  3.774e-02]\n",
+      "     valid: [0.00825 0.      0.      0.00088] 0.00914\n",
+      "          [ 7.5808e-01  1.4200e-03 -4.9000e-04  2.8000e-03  4.4320e-02]\n",
+      "time :  20.058927059173584\n",
+      "Epoch 1170  is ::: \n",
+      "     train: [3.5e-03 1.0e-05 0.0e+00 8.3e-04] 0.00434\n",
+      "          [ 8.9578e-01  9.2000e-04 -4.1000e-04  2.4800e-03  4.3320e-02]\n",
+      "     valid: [0.00791 0.      0.      0.00085] 0.00876\n",
+      "          [ 7.681e-01  1.750e-03 -4.800e-04  2.850e-03  4.135e-02]\n",
+      "time :  20.224788904190063\n",
+      "Epoch 1259  is ::: \n",
+      "     train: [0.00409 0.      0.      0.00067] 0.00477\n",
+      "          [ 8.7831e-01  6.9000e-04 -2.2000e-04  2.3300e-03  3.5720e-02]\n",
+      "     valid: [0.00838 0.      0.      0.0008 ] 0.00918\n",
+      "          [ 7.5422e-01  1.4500e-03 -4.0000e-04  2.7600e-03  3.7950e-02]\n",
+      "time :  20.456215143203735\n",
+      "Epoch 1345  is ::: \n",
+      "     train: [0.00362 0.      0.      0.00106] 0.00468\n",
+      "          [ 8.9229e-01  1.7600e-03 -1.6000e-04  2.8800e-03  3.0060e-02]\n",
+      "     valid: [0.00769 0.      0.      0.00082] 0.00851\n",
+      "          [ 7.7451e-01  1.7100e-03 -3.0000e-04  2.9100e-03  3.5720e-02]\n",
+      "time :  20.127888202667236\n",
+      "Epoch 1435  is ::: \n",
+      "     train: [0.00364 0.      0.      0.00088] 0.00453\n",
+      "          [ 8.9169e-01 -6.4000e-04  8.0000e-05  2.8200e-03  2.6950e-02]\n",
+      "     valid: [0.00759 0.      0.      0.00081] 0.00841\n",
+      "          [ 7.7729e-01  1.7900e-03 -3.8000e-04  2.9500e-03  3.3020e-02]\n",
+      "time :  20.015687704086304\n",
+      "Epoch 1522  is ::: \n",
+      "     train: [0.00359 0.      0.      0.00086] 0.00446\n",
+      "          [ 8.9306e-01  4.9000e-04 -2.7000e-04  2.6700e-03  4.1740e-02]\n",
+      "     valid: [0.00736 0.      0.      0.00078] 0.00814\n",
+      "          [ 7.8411e-01  1.5600e-03 -4.6000e-04  2.8800e-03  3.0780e-02]\n",
+      "time :  20.054631233215332\n",
+      "Epoch 1603  is ::: \n",
+      "     train: [0.00333 0.      0.      0.00082] 0.00416\n",
+      "          [ 9.0099e-01  1.8700e-03 -1.0000e-04  2.5900e-03  4.9030e-02]\n",
+      "     valid: [0.00734 0.      0.      0.00082] 0.00816\n",
+      "          [ 7.8479e-01  1.4900e-03 -2.9000e-04  3.0200e-03  3.0660e-02]\n",
+      "time :  20.184788703918457\n",
+      "Epoch 1694  is ::: \n",
+      "     train: [0.00299 0.      0.      0.00058] 0.00358\n",
+      "          [9.1088e-01 6.6000e-04 3.0000e-05 2.2800e-03 3.3360e-02]\n",
+      "     valid: [0.00725 0.      0.      0.0008 ] 0.00805\n",
+      "          [ 7.8723e-01  1.7200e-03 -3.6000e-04  2.9700e-03  3.1220e-02]\n",
+      "Early Stopped\n",
+      "[Info] Load model from ....    model_save/realdata/airfoil/model_1631\n",
+      "Best Model Is IN ::  model_save/realdata/airfoil/model_1631\n",
+      "@@@ Best Epoch 1631  is ::: \n",
+      "time -13.768643617630005\n",
+      "     train: [0.0037 0.     0.     0.0009] 0.0046\n",
+      "          [ 8.8979e-01  1.5400e-03 -7.1000e-04  2.8500e-03  3.3650e-02]\n",
+      "     valid: [0.00718 0.      0.      0.00077] 0.00796\n",
+      "          [ 7.8948e-01  1.5900e-03 -5.6000e-04  2.9300e-03  3.1160e-02]\n",
+      "### {AS} Params of Adaptive Smoothing\n",
+      "lam_univ::= tensor([0.5000, 0.2490, 0.0186, 0.5000, 0.0052], device='cuda:0',\n",
+      "       dtype=torch.float64)\n",
+      "lam_biv::= tensor([0.8312, 0.0207, 0.7000, 0.0011, 0.5694, 0.2376, 0.5885, 0.0786, 0.2750,\n",
+      "        0.4399], device='cuda:0', dtype=torch.float64)\n",
+      "Total predict time 0.02973794937133789\n",
+      "Total predict time 0.21110296249389648\n",
+      "1352 151\n",
+      "1352 151\n",
+      "tensor([0.5000, 0.2490, 0.0186, 0.5000, 0.0052], device='cuda:0',\n",
+      "       dtype=torch.float64)\n",
+      "tensor([0.8312, 0.0207, 0.7000, 0.0011, 0.5694, 0.2376, 0.5885, 0.0786, 0.2750,\n",
+      "        0.4399], device='cuda:0', dtype=torch.float64)\n",
+      "* Interaction_list [(0, 1), (0, 2), (0, 3), (0, 4), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/gpfs/ysm/home/xs272/reliableAI/XAI/pureGAM/metrics/metrics_torch.py:43: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
+      "  denom = th.square(th.tensor(INT)).mean().item()\n",
+      "/gpfs/ysm/home/xs272/reliableAI/XAI/pureGAM/metrics/metrics_torch.py:55: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
+      "  denom = th.square(th.tensor(int_pred[i])).mean().item()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "compute pureness score : 1.018880844116211\n",
+      "                     train      test\n",
+      "r2                0.879713  0.816475\n",
+      "mse               0.004054  0.006046\n",
+      "time            407.112073  0.029769\n",
+      "log_pure_score    0.000000 -1.465146\n"
+     ]
+    }
+   ],
+   "source": [
+    "X_num_train, X_num_test, X_cate_train, X_cate_test, y_train, y_test = train_test_split(X_num, X_cate, y, test_size=0.1, random_state=seed)\n",
+    "results_folder = \"results/\" + dataset_name\n",
+    "pureGam = run_pureGam(X_num_train, X_cate_train, y_train, X_num_test, X_cate_test, y_test,\n",
+    "                        results_folder=results_folder + '/' + 'pureGam', isPureScore=True, seed=seed, model_output_dir='model_save/realdata/airfoil/')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_scale = 4\n",
+    "N_param_scale = 0.5# todo: 0.5\n",
+    "kwargs = {}\n",
+    "train_loader = torch.utils.data.DataLoader(PureGamDataset_smoothingInTraining(\n",
+    "    X_cate, torch.tensor(X_num).to(device), torch.tensor(y).to(device)),\n",
+    "    batch_size=int(batch_scale * 128), shuffle=False, **kwargs)\n",
+    "\n",
+    "all_contri_univ = []\n",
+    "all_contri_biv = []\n",
+    "for _, batch_N_X, _ in train_loader:\n",
+    "    with torch.no_grad():\n",
+    "        y_hat_S, contri_mat_univ, contri_mat_biv, _, _, _ = pureGam.predict_batch_numerical(batch_N_X)\n",
+    "        all_contri_univ.append(contri_mat_univ.cpu().numpy().T)\n",
+    "        all_contri_biv.append(contri_mat_biv.cpu().numpy().T)\n",
+    "\n",
+    "contri_univ = np.concatenate(all_contri_univ)\n",
+    "contri_biv = np.concatenate(all_contri_biv)\n",
+    "contri = np.c_[contri_univ, contri_biv]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWYAAAD4CAYAAADfPUyRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAA1lElEQVR4nO3deXxURbbA8d9JExIIYUkCCAQQEiDghsPqoICAgCLPGUXUNyKO+BCUJURx18F5o4wLGDAsyaDiMoLgAkZc4DEggmRDEVEImwpJ2DpBIEQgS70/uokk6SQd0kl3ruf7+dwP3V3VfU/R6dPVdeveEmMMSimlfIeftwNQSilVkiZmpZTyMZqYlVLKx2hiVkopH6OJWSmlfEy9WtiHTvtQSrlLqvsCq/y7uJ1zRuSnV3t/NaE2EjOr/LvUxm5qzYj8dABS03/xbiAe1KtLUwB27d3v3UA8rHNEOwB27s3wciSeExURDlj3vVK1lJiVUqq2iL9PdoKrRMeYlVLKx2iPWSllKX716n6PWROzUspSxL/uDwRoYlZKWYr2mJVSysfowT+llFIepz1mpZSlWGEoQ3vMSinlY7THrJSyFFuDut/frPstUEopi9Ees1LKUsRW98eYNTErpSzFzwKJWYcylFLKx2iPWSllKeJX93vMmpiVUpYitro/EFBnE/Pl/3qOFjcM5OyRbDZcObJEWcdp99D1hUdYfVFf8rOPeSnC6tu0/jM+fv8tAAIbNODuiQ/TvkNnL0dVOWMMCfHz2ZKaQkBAAFNjphMZ2alMvbmxs9i9excYQ+s24UTHTKdBgwasX7eW95e/Czjaff8DU+jQMaK2m1GCMYZ/xc9jS2qys00PExFZ9r2YM/t5tn+3jaCgIACmTHuYjhGRfPDeu2xYvxaAwsJCMg7s580l7xMc3LhW21Fadd+r3JMnmRM7i0MHs/CvX5+p0Q/S/uIOXmjJb6wwxlxnE3PGGx/w0/y36f7a8yUeDwy/iLAhfyTv50wvReY5zVu25smZCwhq1Jhvt3zFa/P+yTMvvebtsCq1JS2FrMxM4hctJj19Bwvi5jIr9pUy9e4dP4GGDR0JbFHCQj5OXMmto2+nZcuLmPn8LBoFB5OWmkLc3FiXz69NW9JSOJiZwcJFb7IrfQcL4ubwUuw8l3XvHjeeflcPKPHYzaNu4+ZRtwGQkvwVH33o/aQM1X+vli1bQseOETzx1AwOHNjPwvmv8OzMF2u7GZZTZ/v8ORvTyM85Xubxbi89xo7HXgRT95ca7Nz1coIaOT68kV0uJcd+xMsRuScpaTODBg9BRIiK6sapU7nk5GSXqXfug26M4ezZM4izo9O12yU0Cg4GICqqK/bso7UWe3lSkjZx7eChiAhdKmiTO75cv47+Awd5OMILU9336sD+n7m8+5UAtG3bjiOHD3PsmHd/pYqfuL35qkoTs4hEicgjIjJXROY4b3etjeCqqsWNgziddYST29K9HYrHrV/zEZf3uMrbYbgl224nrHmL4vuhYWFk2+0u68bOfpG7/jKajIwD3DjyT2XKV6/+jB49etVUqG5ztKl58f2wsObltuntN15jyv33sihhPvn5Z0uUnTl9mq+3pHJVv2tqNF53Vfe96tChI5s3bQRgV/pOjhw5TLbdu1+kfjZxe6uMiLwmIkdEZPt5j70oIjtFZJuIfCgiTct57k8i8p2IbBWRtCq1oZKgHgGW4li5NgVIdd5eIiKPVvC88SKSJiJpCQkJVYnngvk1CCTysQnsmjGnVvZXm37YlsYXaxK5fewkb4fiprK/VkRcfwiiY6az+K2lhLdtx8YN60uUbft2K2tWf8rd9/xPTQRZJa5+f7lq05i772V+wmJmzZlP7skTvL98aYnylOTNdO12iU8MYzhU770aNfp2cnNPMmXSfSR+tIKOEZHYbLaaDLhSYhO3NzcsBoaXemwNcKkx5nJgF/BYBc+/1hjT3RjTsyptqGyMeRxwiTEm//wHRWQ28D3wT1dPMsYkAOcysln1wKyqxHRBgiLa0fDicK7ZshJwjDVfk/IBm/54K2cOu+4B+KI1q5azbrWjDdOffpmTJ35hUdxzTP9bLMGNm3g5uvKtSlzJ559/AkCnTl2wH/1t2CXbbickNLTc59psNq7pP4AP3lvOkKGOz8CPP+7jlTmzmfH352jc2DtJbFXiCtY42xTZqQv2o7/1BO32oy7bFBLieMzfvz6DrxvOiveXlSj/csM6rhng3WEMT75XDRsGER0zHXAMc9z71zG0vOiimm1ALTLGbBCRi0s9tvq8u0nAKE/vt7LEXAS0Bn4u9XgrZ5nPOLl9F//X5o/F96/dvZaNfUfVuVkZ1424letG3AqA/eghYmc+yoRpM2jVxreXdh8x8iZGjLwJgNSUZD5OXEn/AdeSnr6DhkFBxQnrHGMMBw9m0bp1G4wxpCQnEd62LQBHjhxh5j+eIeahR2gTHl7rbTlnxMg/McL5kz0tJYlViSu4ZsC17ErfQZCLNgHk5GQTEhKKMYbkzZtod94MhVOncvn+u23ETK+og1XzPPle5ebmEhAQgL+/P6s//5RLLr2seDzaW8TP/UNnIjIeGH/eQwnOjqW77gHeLafMAKtFxADxVXndyhJzNLBWRHYDB5yPtQMiAa/+ru7+1ixCB/SmflgzBv34Bbv//goHXn/PmyF53IdLXyX35HEWL3wBcPRW/nf2G16OqnI9e/UmLTWZ8ePGOqZgTXuouGzG048zeWoMzZqFEDvrBfLy8jA4xirvnzQFgKXvvMWJkydYMH8uADY/Gy/Pne+NphTr0asPaanJTBg3hoCAQCZPm15c9venH+OBqQ8SGhrG7Bee48Tx4xgMHTpGMHHStOJ6SV9tpPsfehAY2MAbTXCpuu9VxoH9zJ71PH5+Ntq1a8eUqQ96qSW/qcpBvVK/7qu2H5EngALg3+VU6WeMyRKRFsAaEdlpjNng1mubSmYviIgf0Btog2N8OQNINcYUuhm/WeXfxc2qdcOIfMfBxdT0X7wbiAf16tIUgF1793s3EA/rHOH4pbFzb4aXI/GcqAjHrwiLvlfVnirx9eCr3Z6S9Ye1Gyvdn3Mo42NjzKXnPTYWmAAMNsbkufEaM4BcY8xL7sRV6TxmY0wRjnEUpZTyeTV9gomIDAceAQaUl5RFJAjwM8acdN4eCvzd3X3U2XnMSinliifnMYvIEmAz0EVEMkRkHBAHBOMYntgqIguddVuLyCfOp7YENorItzhmtK0yxnzmbhvq7Jl/SinlSlUO/lXGGHOHi4dfLaduFnCD8/Y+4IoL3a/2mJVSysdoj1kpZSm+fKq1uzQxK6UsRa8up5RSPkZ7zEop5WM8efDPW+p+C5RSymK0x6yUshQdylBKKR9jhcSsQxlKKeVjtMeslLIUK/SYNTErpSzFCrMyNDErpSzFCieY1P2vFqWUsphKL5TvATW+A6WUZVS7u7vv7hvdzjkdF3/sk91rHcpQSlmKjjG7yUpLMMFvyzAdf2mqdwPxoCYPzQHgs61nvRyJZw3vXh+w1jJM55bLOrxji5cj8ayWXXt45HWsMCuj7n+1KKWUxehQhlLKUqzQY9bErJSyFCuMMdf9FiillMVoj1kpZSl+9WzeDqHatMeslFLlEJHXROSIiGw/77EQEVkjIrud/zYr57nDRSRdRPaIyKNV2a8mZqWUtYi4v1VuMTC81GOPAmuNMZ2Atc77pUIQGzAPuB7oBtwhIt3cbYImZqWUKocxZgOQU+rhm4A3nLffAP7k4qm9gT3GmH3GmLPAUufz3KKJWSllKeIn7m8i40Uk7bxtvBu7aGmMOQjg/LeFizptgAPn3c9wPuYWPfinlLKUqkyXM8YkAAk1EYar3bn7ZE3MSilLqYUTTA6LSCtjzEERaQUccVEnA2h73v1wIMvdHehQhlLKUsTPz+3tAn0EjHXeHgusdFEnFegkIh1EpD5wu/N5btHErJRS5RCRJcBmoIuIZIjIOOCfwHUishu4znkfEWktIp8AGGMKgEnA58AOYJkx5nt396tDGUopS/HkUIYx5o5yiga7qJsF3HDe/U+ATy5kv9pjVkopH2OJHvOm9Z/x8ftvARDYoAF3T3yY9h06ezmqqqnfYyD1L+sLQOHRLH797B0oLCgu9wtpQYPh/42tRVtOb/yYs2nrvBVqlXyX+h9WLYvDT/zws9n489hHiIj6Q5l6xhhWvfsKW5NW4yd+9Bt6GwOu/4sXInbNGENC/Hy2pKYQEBDA1JjpREZ2KlNvbuwsdu/eBcbQuk040THTadCgAR+8t4z169cCUFhYRMaB/by9ZDnBwY1ruyku/fOVeL5K+4ZmTRrzxtwXypR/mZzGq+8sx0/8sNn8mDxuDJd3i/JCpJXTq8v5iOYtW/PkzAUENWrMt1u+4rV5/+SZl17zdlhuk0ZNCPhDf06+PhMK8mkw8m78o/5A/vcpxXXM6TxO/+cD6kVe5sVIq67zZX25tOe1iAiZP6ezOPYhnng5sUy95PUr+MV+iMdnf4Sfnx8nj2d7IdrybUlLISszk/hFi0lP38GCuLnMin2lTL17x0+gYcMgABYlLOTjxJXcOvp2bh41mptHjQYgJXkzKz/8wGeSMsDwQf358w1DeW7OApflPS6/lKt790BE2PvTfv724hzenjerlqN0k15dzjd07no5QY0cf+SRXS4lx+5q9oqPEz+knr/z3/qY3OMlik1eLoWH9kNRoZcCvDABgQ0R56mvZ8/8ipSzpNumNcsYNmoCfs4PVXCT0FqL0R1JSZsZNHgIIkJUVDdOncolJ6fsl8e5pGyM4ezZMy7P+v1i/Tr6D7y2pkOuku6XdKVxo0blljdsEFj8Pv56+rS7pzN7hYi4vfkqS/SYz7d+zUdc3uMqb4dRJSb3OGfS1hE8fgamIJ+Cn3ZS8HO6t8PymG9T1vLxklhyj+cw/tF5LuvYDx/gm68+Y1vqWho1bsbNdz9Gi1btaznS8mXb7YQ1/+0Er9CwMLLtdkJCyn6BxM5+kS1pKbRt15577r2vRNnp06f5eksaE+6fVOMxe9qGpFQS3lrKseMneP7J6d4Op1x6PWYf88O2NL5Yk8jtY+vYH31AA/wjL+Xkv57h5MKnEP/6+Hft6e2oPOaK3oN54uVExj00h0/ejXNZpyD/LPX8A3ho5rtcNWgUSxY+XctRVqbsSVvl9biiY6az+K2lhLdtx8YN60uUpSYn0bXbJT41jOGu/n178fa8WTz7WAyvvrPc2+FY2gUnZhH5awVlxeefJyTUxNmOsGbVch6feiePT72TY9lH2f/jbhbFPce0J14kuHGTGtlnTanXvgtFx3Mwv56CoiLyd2/D1qaDt8O6YF9+voQXHh7FCw+P4njOb8NKkd16Yj+cQe6JY2We0zS0JVf0GQLA5b0Hk/XzrlqLtzyrElcyZdJ9TJl0HyEhodiP/taWbLudkNDyh1tsNhvX9B/Apk0bSzy+YcN6+g/wrWGMqup+SVcyDx3hlxMnvB2KS1W5Voavqs5QxjPA664KSp1/bmpilezrRtzKdSNuBcB+9BCxMx9lwrQZtGrTzuP7qmnmxDFsrdpDPX8oyKde+86O8eQ66pphd3DNMMf0z6OH9mOMQUQ4sO8HCgvyCQpuWuY5l/UaxO7vUwht8Wf2/JBGcx8Yxhgx8iZGjHRcECw1JZmPE1fSf8C1pKfvoGFQUJlhDGMMBw9m0bp1G4wxpCQnEd72t7NyT506xfbvtvHg9EdqtR2ekHHwEG0uaomIkL73RwoKCmgSHOztsFyzwFBGhYlZRLaVVwS09Hw4F+bDpa+Se/I4ixc6pvnYbDb+d/YblTzLdxQe+pn8Xd/SaMx0MEUUHs7g7LavqH9FPwDOfrsJaRhMozEPIfUDwRQR0GMgJ19/Ds6e8XL0Ffs2eQ2pGxKx2erhXz+AsdEvFg8BLJw5kTvue4YmIS0YctM43nrlUdavepOAwIbccd8zXo68pJ69epOWmsz4cWMd0+WmPVRcNuPpx5k8NYZmzUKInfUCeXl5GKBDh47cP2lKcb3NX23kyj/0IDCwgRdaULFnZr3CN9t3cPzESW4ZN4m/3n4LhYWOA803DR/CF5tT+Hzdl9Sz1SMgwJ8ZD0322YNnvtwTdpcYU/4Fj0TkMDAMKP3bU4CvjDGt3dhHjfSYvalXl6YAHH9pqncD8aAmD80B4LOtZ70ciWcN714fgF176+4vkNI6Rzh+FR7escXLkXhWy649wPVV2aok5x/3uX0Vt5An430yi1c2lPEx0MgYs7V0gYisr4mAlFKqOkQsPpRhjBlXQdl/ez4cpZSqJgsMZdT9rxallLIYy51gopT6ffOrZ/N2CNWmPWallPIx2mNWSlmLBQ7+1f0WKKWUxWiPWSllKVY4wUQTs1LKWqx+SrZSStU1vnqqeFVoYlZKWYsFesx1vwVKKVUDRKSLiGw9bzshItGl6gwUkePn1fHIhcS1x6yUshRPHfwzxqQD3QFExAZkAh+6qPqlMeZGj+zUSXvMSilVucHAXmPMz7WxM03MSilrsdnc3s5fbcm5jS/nVW8HlpRTdpWIfCsin4rIJZ5ogg5lKKV+t0qttuSSiNQH/gt4zEXx10B7Y0yuiNwArAA6VTeuCi+U7yE1vgOllGVUe4D4VPwTbuecoPuerXR/InIT8IAxZqgbdX8Cehpj7O7G4Ir2mJVS1uL5M//uoJxhDBG5CDhsjDEi0hvH8HB2dXdYK4nZSsv6wG9L+1hpGaZzSzAdm3m/lyPxrGaPzQfgx717vByJ53SIiARg7759Xo7EsyI6dvR2CGWISEPgOuC+8x6bAGCMWQiMAiaKSAHwK3C78cAwhPaYlVKWIh48wcQYkweElnps4Xm344A4j+3QSROzUspa9JRspZTyMXpKtlJKKU/THrNSylp0KEMppXyLJw/+eYsmZqWUteiaf0oppTxNe8xKKWvRNf+UUsq3iA5lKKWU8jTtMSulrEWHMpRSysdYYChDE7NSylr0BBOllPIxFjjBpO63QCmlLKZO9JiNMSTEz2dLagoBAQFMjZlOZGTZZbXmxs5i9+5dYAyt24QTHTOdBg0asH7dWt5f/i4AgQ0acP8DU+jQMaK2m1Gh71L/w6plcfiJH342G38e+wgRUX8oU88Yw6p3X2Fr0mr8xI9+Q29jwPV/8ULE7gnoNYiAK/4IQOHRTE59/BYUFhSX12vXiUa3TKDwuGMlnvz0rZze9KlXYq1IWloaC+ITKCoqYviwodw2enSJ8gMHDjDr5Vj27tnD2LF3MeqWW4rLZr8cS3JKCk2bNiV+wfzaDt1txhjiFy4kNTWVgIAAYh58kMjIyDL1Ej/6iBUrVnDw4EGWLF1KkyZNvBBtBXSMuXZsSUshKzOT+EWLSU/fwYK4ucyKfaVMvXvHT6BhwyAAFiUs5OPEldw6+nZatryImc/PolFwMGmpKcTNjXX5fG/qfFlfLu15LSJC5s/pLI59iCdeTixTL3n9Cn6xH+Lx2R/h5+fHyePVXsWmxkijJgT0HMiJf/0vFOQT9Kdx1O/Wk7PfJZWol5+xh1PLF3gpysoVFhYyb/4Cnnv2H4SFhTElehp9+/alfbt2xXWCg4OZOOE+Nm/eXOb51w0ZwsiRN/LSrNm1GXaVpaWmkpmVxaJXXyV9507i4uKIjY0tU69bt2707tOHRx5+uPaD/J2oE18tSUmbGTR4CCJCVFQ3Tp3KJSenbEI6l5SNMZw9e6b4GEDXbpfQKDgYgKiortizj9Za7O4KCGyIOAM+e+ZXpJw1KTetWcawURPwc46jBTcJdVnPV4ifDann7+jF+NenKPe4t0OqsvRdu2jVujWtWrXC39+fAf37s3lzyS+Xpk2b0qVzZ2y2sn2dyy67lGDn358vS0pKYvDgwY7PWdeunMrNJScnp0y9iMhIWrZs6YUI3WSzub/5qEp7zCISBbQBko0xuec9PtwY81lNBndOtt1OWPMWxfdDw8LIttsJCSmblGJnv8iWtBTatmvPPffeV6Z89erP6NGjV43Ge6G+TVnLx0tiyT2ew/hH57msYz98gG+++oxtqWtp1LgZN9/9GC1ata/lSN1jco9zOvn/aPLAPzAF+eT/uIOCH3eUqVevTQeC73kck3ucvP98QJH9oBeiLV92djbNw8KK74eFhZGenu7FiGqG3UU77XY7ISEhXozq96nCHrOITAFWApOB7c5lvM95roLnjReRNBFJS0hI8ECYZdc2lHKmxETHTGfxW0sJb9uOjRvWlyjb9u1W1qz+lLvv+R8PxOR5V/QezBMvJzLuoTl88q7rZcQK8s9Szz+Ah2a+y1WDRrFk4dO1HKX7JLAB/p0u5/j8pzn+ymOIfwD1L+ldok7BoQMcn/cUJ197jtNb1tPolrJfpt7mam1NC8zIKstlO+tgQ0Xc33xUZT3m/wF6GGNyReRi4D0RudgYMwfK+a0NGGMSgHMZ2VzIKtmrElfy+eefANCpUxfsR48Ul2Xb7YSElv8T3mazcU3/AXzw3nKGDB0OwI8/7uOVObOZ8ffnaNy4cZXjqQlffr6EzWvfB+C+R+fTJMTxqyCyW0/+PT+D3BPHaNS4WYnnNA1tyRV9hgBwee/BvLPgqdoNugrqXRxF0fFszK+OH1r56VuxhXeE71N+q3T2dPHNgr3fw9DbkQZBmF9P1Xa45QoLC+Oo3V58317Or7W6KDExkc8/c/zw7dS5c5l2hlbwOfNZFpguV1litp0bvjDG/CQiA3Ek5/ZUkJg9YcTImxgx0tFBT01J5uPElfQfcC3p6TtoGBRU5oNhjOHgwSxat26DMYaU5CTC27YF4MiRI8z8xzPEPPQIbcLDazLsKrlm2B1cM+wOAI4e2o8xBhHhwL4fKCzIJyi4aZnnXNZrELu/TyG0xZ/Z80MazX10GAOg6MQx6rW+GOr5Q0E+9S7uQuHBkl/SEtQYc+oEALZW7RERn0rKAF06dyYrK5NDhw4RGhrKFxs28MjD070dlkeMHDmSkSNHApCSkkJiYiIDBgwgfedOgoKCfvfDGCLyE3ASKAQKjDE9S5ULMAe4AcgD7jbGfF3d/VaWmA+JSHdjzFYAZ8/5RuA14LLq7txdPXv1Ji01mfHjxjqmy017qLhsxtOPM3lqDM2ahRA76wXy8vIwQIcOHbl/0hQAlr7zFidOnmDB/LkA2PxsvDzXt6YtfZu8htQNidhs9fCvH8DY6BeLf0YunDmRO+57hiYhLRhy0zjeeuVR1q96k4DAhtxx3zNejrx8hVk/cTb9Gxrf8xgUFVFw+ABntm6k/pXXAHD2my+pH3UlAVdegykqgoJ8cle+5uWoy7LZbNw/cSJPPPkURUVFDB16HRe3b8+qVY5fdCNG3EBOTg5TpkaTl5eH+PmxYsVK4uMXEtSwITOff55t277jxIkT3DnmLu688y8MHzbMy60qq1evXqSmpjLunnsICAxk2rRpxWVPP/UUU6OjCQ0NZeXKlby3fDnHjh3jgfvvp2evXkRHR3sv8NI8P0RxrTHGXk7Z9UAn59YHWOD8t1rE1fhZcaFIOI5viUMuyvoZYza5sY8LGsrwZZ0jHNOkPtt61suReM7w7vUBODbzfi9H4lnNHnN8Af+4d4+XI/GcDhGOucV79+3zciSeFdGxI3jgl/jpTxLKT2qlBN4wvsL9OXvMPctLzCISD6w3xixx3k8HBhpjqnUEu8LBGGNMhquk7CxzJykrpVTt8vNzezt/ooJzG1/q1QywWkS2uCgDx4y1A+fdz3A+Vi114gQTpZSqCaUmKrjSzxiTJSItgDUistMYs+G8clc9brd77OWp+4cvlVLqfB6cLmeMyXL+ewT4EOhdqkoG0Pa8++FAVnWboIlZKWUt4uf+VtHLiASJSPC528BQYHupah8Bd4lDX+B4dceXQYcylFJW47lZGS2BD52zo+oB7xhjPhORCQDGmIXAJzimyu3BMV3ur57YsSZmpZRywRizD7jCxeMLz7ttgAc8vW9NzEopa/kdnPmnlFJ1ivHha2C4q+5/tSillMVoj1kpZS26golSSvkYTcxKKeVbdIxZKaWUx2mPWSllLTqUoZRSPsYCQxmamJVS1mKBE0wqvFC+h9T4DpRSllHt7u6prz5wO+cE/fFmn+xe1/2vFqWUsphaGcrYuTejNnZTa6IiHAu6WmnJrHPLZVlpCSb4bRmm7O1feTkSzwm99I8A7Nu718uReFbHiAjPvJAe/FNKKd9iLJCY634LlFLKYrTHrJSyFp0up5RSvsUKQxmamJVS1mKBHnPd/2pRSimL0R6zUspadChDKaV8i172UymlfI34ub9V9DIibUVknYjsEJHvRWSqizoDReS4iGx1bk97ognaY1ZKKdcKgAeNMV+LSDCwRUTWGGN+KFXvS2PMjZ7csSZmpZSlmOpfB8nxOsYcBA46b58UkR1AG6B0YvY4HcpQSlmKET+3NxEZLyJp523jXb2miFwMXAkkuyi+SkS+FZFPReQST7RBe8xKqd8tY0wCkFBRHRFpBLwPRBtjTpQq/hpob4zJFZEbgBVAp+rGpT1mpZSlGD+b21tlRMQfR1L+tzHmgzL7MuaEMSbXefsTwF9EwqrbBk3MSinlgogI8Cqwwxgzu5w6FznrISK9ceTU7Oruu04MZRhj+Ff8PLakJhMQEMDUmIeJiOxcpt6c2c+z/bttBAUFATBl2sN0jIjkg/feZcP6tQAUFhaScWA/by55n+DgxrXajtKMMSTEz2dLaoqzXdOJjCz7K2hu7Cx2794FxtC6TTjRMdNp0KABH7y3jPXF7Soi48B+3l6y3OvtSktLY0F8AkVFRQwfNpTbRo8uUX7gwAFmvRzL3j17GDv2Lkbdcktx2eyXY0lOSaFp06bEL5hf26G75dl5r7Ip7VuaNWnMv2P/UaY891Qez8xJ4LA9h8LCQu64aTg3DrrGC5G6lpaWxsL4eOf7M4zRpd4fYwwL4+NJTU0lICCAB2NiiIx0XNc6NzeX2Dlz+PnnnxERpkVH07VrV9588002JyXh5+dHkyZNeDAmhtDQUG80z5PXyugHjAG+E5GtzsceB9oBGGMWAqOAiSJSAPwK3G48sCxUnUjMW9JSOJiZwcJFb7IrfQcL4ubwUuw8l3XvHjeeflcPKPHYzaNu4+ZRtwGQkvwVH33o/aQMjnZlZWYSv2gx6ek7WBA3l1mxr5Spd+/4CTRs6PiyWZSwkI8TV3Lr6Nu5edRobh7l+FClJG9m5YcfeL1dhYWFzJu/gOee/QdhYWFMiZ5G3759ad+uXXGd4OBgJk64j82bN5d5/nVDhjBy5I28NMtlB8Un3DDwakZdP5i/z13ksvz9z/7DxW1b8+Lj0Rw7foLbpzzOsGuuwt/f+x83x/szn+eefZawsDCmRkfTp9T7k5qWRlZmJq8uWsTO9HTi4uKIjY0FYGF8PD179ODJJ54gPz+fM2fOAHDLqFHcddddAKxcuZJ33nmHyZMn13r7PMkYs5FKlroyxsQBcZ7ed50YykhJ2sS1g4ciInSJ6sapU7nk5FzYr4Uv16+j/8BBHo7wwiQlbWbQ4CGICFEVtOtcUjbGcPbsGZfXaPli/Tr6D7y2pkOuVPquXbRq3ZpWrVrh7+/PgP792bw5qUSdpk2b0qVzZ2y2sonqsssuJTg4uLbCvSBXXtKFxo0alVsuAnm/nsYYw6+nz9C4URA2m2981Hbt2kXrUu9PUqkvyKSkJAYPHoyI0DUqitxTp8jJyeFUXh7bt29n2LBhAPj7+9PI+f8Q1LBh8fNPnz7t3QsJibi/+Sjf+GupRLbdTljz5sX3w8Kak223u6z79huvMeX+e1mUMJ/8/LMlys6cPs3XW1K5qp9v/Kx0tKtF8f3QsLBy2xU7+0Xu+stoMjIOcOPIP5UoO336NF9vSeOP/a6uyXDdkp2dTfOw3459hIWFkZ1d7SG3OuWW6wfzc8ZB/uveaYyJeYroe/4bPx9ZudnuxvtT9vMWht1u59DBgzRp0oTZL7/MA5MmERsb60jCTovfeIMxd93FuvXrGTNmTM03phxVmS7nqyqNTER6i0gv5+1uIhLjnBZSa1wN2IiLb7sxd9/L/ITFzJozn9yTJ3h/+dIS5SnJm+na7RKv/9z/TdmWuWoXQHTMdBa/tZTwtu3YuGF9ibLU5CSfaZer4TUf7pjUiOSt2+nUoR0fLXqZN156htmL3uZU3q/eDsvB1fBnqTeovM9bYWEhe/bsYcQNNzAvLo7AwECWLVtWXOfusWN56803uXbgQBITEz0cuPsM4vbmqypMzCLyN2AusEBEZuIYS2kEPCoiT1TwvOJJ2wkJFU4RLNeqxBVETxpP9KTxhISEYj96tLjMbj9KiIsDCyEhoYgI/v71GXzdcHan7yxR/uWGdVwzwLvDGKsSVzJl0n1MmXSfs11Hisuy7XaX7TrHZrNxTf8BbNq0scTjGzasp/8A7w9jgKN3dfS8Xr/dbickxDsHgbxl1X82MqBPD0SE8FYtadUijJ8zD3o7LMD1+xMaElKmTsnPm53Q0FDCwsIICwsjKioKgKuvvpo9LhaEHThwIJs2baqhFlTu99BjHoXjyGR/4AHgT8aYvwPDgNvKe5IxJsEY09MY03P8eJcn0lRqxMg/ERuXQGxcAn2v6se6tasxxpC+8weCgoJcftjPjc8aY0jevIl2F3coLjt1Kpfvv9tGn6v+eEHxeMqIkTcxNy6euXHx9L2qH/9Z+38YY9i58wcaumiXMYasrMzi2ynJSYS3bVtcfurUKbZ/t42+V11Vq+0oT5fOncnKyuTQoUPk5+fzxYYN9O3bx9th1aqLwkJJ+85x1m7OL8fZn3WI1i2bV/Ks2tG5c2eysrJKvT99S9Tp26cPa9euxRjDjp07nZ+3EEJCQmjevDkZGY5V77du3Uo750HDzMzM4ucnJScTHh5ee42yoMoOExcYYwqBPBHZe+6sF2PMryJSVPPhOfTo1Ye01GQmjBtDQEAgk6dNLy77+9OP8cDUBwkNDWP2C89x4vhxDIYOHSOYOGlacb2krzbS/Q89CAxsUFthV6pnr96kpSYzftxYx3S5aQ8Vl814+nEmT42hWbMQYme9QF5eHgbo0KEj90+aUlxv81cbudKH2mWz2bh/4kSeePIpioqKGDr0Oi5u355Vqz4BYMSIG8jJyWHK1Gjy8vIQPz9WrFhJfPxCgho2ZObzz7Nt23ecOHGCO8fcxZ13/oXhzoNNvuLp2Qv55vud/HIyl5v+J4Z7b/sTBYWFAPx52LXcfetI/hH3KndOexJj4P47b6VpY984oGmz2Zg4cSJPPvkkhUVFDB06lPbt27Nq1SoARowYQa9evUhNTeWeceMIDAhg2rTfPkcTJ0zghRdeIL+ggFYXXVRc9vrrr5ORmYmI0KJFCyZPmuSV9gGWGDuTiqbciUgycK0xJk9E/IwxRc7HmwDrjDF/cGMfZufeDM9E6yOiIhy9gV1793s5Es/pHOHo+fy4d4+XI/GsDhGO+bfZ27/yciSeE3qp41ffPhfDCHVZx4gIqGR6mjuO/pDi9jzi5t16+2QWr6zH3N8YcwbgXFJ28gfG1lhUSil1gYqk8lOtfV2FiflcUnbxuB1wPa9LKaVUtXj/VCSllPIgX55t4S5NzEopS/Hl+cnuqvtfLUopZTHaY1ZKWYoOZSillI8xFpjHrIlZKWUpOsaslFLK47THrJSyFB1jVkopH6NDGUoppTxOe8xKKUuxwrUytMeslFI+RhOzUspSPLmCiYgMF5F0EdkjIo+6KBcRmess3yYi7lwKuVKamJVSygURsQHzgOuBbsAdItKtVLXrgU7ObTywwCP7ruhC+R5S4ztQSllGtadU7Nu71+2c0zEiotz9ichVwAxjzDDn/ccAjDEzz6sTD6w3xixx3k8HBhpjqrXIo/aYlVKWYkTc3s5fONq5nb9IaRvgwHn3M5yPUcU6VVYrszKstAQT/LYM0+EdW7wciee07NoDgL379nk5Es+K6NgRsNYyTM4lmDix5XMvR+JZjXt4Zm1HY9zvdBtjEoCEcopdvVDp3rg7dapMp8sppSzFeG4gIANoe979cCDrAupUmQ5lKKWUa6lAJxHpICL1gduBj0rV+Qi4yzk7oy9wvLrjy6A9ZqWUxXjqlGxjTIGITAI+B2zAa8aY70VkgrN8IfAJcAOwB8gD/uqJfWtiVkqpchhjPsGRfM9/bOF5tw3wgKf3q4lZKWUpRRYYoa37LVBKKYvRHrNSylKscNlPTcxKKUupyjxmX6VDGUop5WO0x6yUshQdylBKKR+jiVkppXyMFRKzjjErpZSP0R6zUspSrDArQxOzUspSiiwwlKGJWSllKVYYY64TidkYQ0L8fLakphAQEMDUmOlERnYqU29u7Cx2794FxtC6TTjRMdNp0KABuSdPMid2FocOZuFfvz5Tox+k/cUdvNCS8v3zlXi+SvuGZk0a88bcF8qUf5mcxqvvLMdP/LDZ/Jg8bgyXd4vyQqRVY4whfuFCUlNTCQgIIObBB4mMjCxTL/Gjj1ixYgUHDx5kydKlNGnSxAvRlpSWlsbC+HiKiooYPmwYo0ePLlFujGFhfHxx2x6MiSluW25uLrFz5vDzzz8jIkyLjqZr1668+eabbE5Kws/PjyZNmvBgTAyhoaHeaF4Jh7KPMWPBW2T/chIR4c+D/sgd1w8sUeetxLV8+lUaAIWFRfyUeYjV8c/RpFGQFyK2tjqRmLekpZCVmUn8osWkp+9gQdxcZsW+UqbeveMn0LCh449kUcJCPk5cya2jb2fZsiV07BjBE0/N4MCB/Syc/wrPznyxtptRoeGD+vPnG4by3BzXazn2uPxSru7dAxFh70/7+duLc3h73qxajrLq0lJTyczKYtGrr5K+cydxcXHExsaWqdetWzd69+nDIw8/XPtBulBYWMi8+fN57tlnCQsLY2p0NH369qV9u3bFdVLT0sjKzOTVRYvYmZ5eom0L4+Pp2aMHTz7xBPn5+Zw5cwaAW0aN4q677gJg5cqVvPPOO0yePLnW21daPT8/ov/yZ6I6tOXUr6e564kX6XNZFzqGtyquM2bkYMaMHAzAhi3fseTT9T6ZlK0wxlwnZmUkJW1m0OAhiAhRUd04dSqXnJzsMvXOJWVjDGfPnkGc78+B/T9zefcrAWjbth1HDh/m2LFjtRa/O7pf0pXGjRqVW96wQSDibNCvp09T3Dgfl5SUxODBgx3vXdeunMrNJScnp0y9iMhIWrZs6YUIXdu1axetW7emVatW+Pv7M6B/f5I2by5R5/y2dY2KIvfUKXJycjiVl8f27dsZNsyxVJK/vz+NnO9tUMOGxc8/7UPvY1izJkR1cCzEEdQgkIvbtOTosePl1l+9+WuG/rFHbYVXJQZxe/NVVe4xi8ibxpi7aiKY8mTb7YQ1b1F8PzQsjGy7nZCQsj8BY2e/yJa0FNq2a889994HQIcOHdm8aSOXXHIpu9J3cuTIYbLtR2nWrFmttcETNiSlkvDWUo4dP8HzT073djhusWdn0zwsrPh+WFgYdrudkJAQL0ZVOVdxp6enl6jj+LtsXqKO3W7HZrPRpEkTZr/8Mvv27aNTZCQTJkwgMDAQgMVvvMHatWsJCgrin//8Z+00qAqyjmaT/lMml0S0d1l++sxZNn+7g+l3j6rlyH4/Kuwxi8hHpbZE4OZz9yt4XvHKswkJ5a1zWBVl1zaUcnoa0THTWfzWUsLbtmPjhvUAjBp9O7m5J5ky6T4SP1pBx4hIbDabB+KqXf379uLtebN49rEYXn1nubfDcY9x/73zKS7iLt27dbXipohQWFjInj17GHHDDcyLiyMwMJBly5YV17l77FjeevNNrh04kMTERA8HXj15p8/wyMuvEjPmZho1bOCyzoavt3N55w4+OYwBjqEMdzdfVVmPORz4AViE4+9QgJ5AhYObpVaeNReySvaqxJV8/rlj4YBOnbpgP3qkuCzbbiekggMmNpuNa/oP4IP3ljNk6HAaNgwiOmb6udi4969jaHnRRVWOyVd0v6Qrzx06wi8nTtC0cWNvh1NGYmIin3/2GQCdOnfmqN1eXGa3233iYFdlwsLCysZdqpcfFhaG/ejRknWcbQsLCyMqynFw9uqrr2bZ8rJfpAMHDuRvM2Yw5s47a6IJVVZQUMgjL7/K8H49GdT7inLrrdn8NcN8dBgDrDEro7Ix5p7AFuAJHIsMrgd+NcZ8YYz5oiYDGzHyJubGxTM3Lp6+V/XjP2v/D2MMO3f+QMOgoDLDGMYYsrIyi2+nJCcR3tYxZpabm0t+fj4Aqz//lEsuvax4PLquyDh4COPsxaXv/ZGCggKaBAd7OSrXRo4cSdy8ecTNm8dVV13F2rVrHe/djh0EBQX5/DAGQOfOncnKyuLQoUPk5+fzxYYN9O3bt0Sdvn36FLdtx86dxW0LCQmhefPmZGRkALB161baOQ8aZmZmFj8/KTmZ8PDw2mtUBYwx/G/CO1zcpiV/GTGo3Hq5eb/y9Y49DOhxWS1GVzWW7zEbY4qAl0VkufPfw5U9pyb07NWbtNRkxo8b65guN+2h4rIZTz/O5KkxNGsWQuysF8jLy8PgGFe+f9IUADIO7Gf2rOfx87PRrl07pkx9sLabUKlnZr3CN9t3cPzESW4ZN4m/3n4LhYWFANw0fAhfbE7h83VfUs9Wj4AAf2Y8NLlODAn06tWL1NRUxt1zDwGBgUybNq247OmnnmJqdDShoaGsXLmS95Yv59ixYzxw//307NWL6Ohor8Vts9mYOHEiTz75JIVFRQwdOpT27duzatUqAEaMGFHctnvGjSMwIKBE2yZOmMALL7xAfkEBrS66qLjs9ddfJyMzExGhRYsWTJ40ySvtK+3b9H18sjGVyLat+e/HngfggdE3cijbcZD8liFXA7AudRt9LouiQWCA12KtTJG3A/AAMa7G0sqrLDIC6GeMebwK+7igoQxf1jnC0fs5vGOLlyPxnJZdHT9N9+7b5+VIPCuiY0cA9u3d6+VIPKdjRAQAJ7Z87uVIPKtxj2FA9cchknYedzup9Y1q4pO9myr1fo0xq4BVNRSLUkpVW20NUYjIi8BI4CywF/irMeYXF/V+Ak4ChUCBMaZnZa9dJ+YxK6WUD1oDXGqMuRzYBTxWQd1rjTHd3UnKUEfO/FNKKXcVmdrpbxpjVp93Nwnw2MRu7TErpX63zj/nwrmNv8CXugf4tJwyA6wWkS3uvr72mJVSllKVecylzrkoQ0T+D3B10sMTxpiVzjpPAAXAv8t5mX7GmCwRaQGsEZGdxpgNFcWliVkpZSlF7k80q5QxZkhF5SIyFrgRGGzKmeJmjMly/ntERD4EegMVJmYdylBKqQsgIsOBR4D/MsbklVMnSESCz90GhgLbK3ttTcxKKUupxavLxQHBOIYntorIQgARaS0inzjrtAQ2isi3QAqwyhjzWWUvrEMZSilLqa15zMaYsis+UDx0cYPz9j6g/AuPlEMTs1LKUqpwMrPP0qEMpZTyMdpjVkpZiq6SrZRSPsaXL+fpLk3MSilL0TFmpZRSHqc9ZqWUpVhhaakqXSj/Alngh4VSqpZUO6t+tvWs2zlnePf6PpnFayMx1xoRGe+8KImlWLFdVmwTWLNdVmyTr7PaGPOFXrLP11mxXVZsE1izXVZsk0+zWmJWSqk6TxOzUkr5GKslZquOg1mxXVZsE1izXVZsk0+z1ME/pZSyAqv1mJVSqs7TxKyUUj7GEolZRIaLSLqI7BGRR70djyeIyGsickREKl2Gpi4RkbYisk5EdojI9yIy1dsxVZeIBIpIioh862zTM96OyZNExCYi34jIx96O5feizidmEbEB84DrgW7AHSLSzbtRecRiYLi3g6gBBcCDxpiuQF/gAQu8X2eAQcaYK4DuwHAR6evdkDxqKrDD20H8ntT5xIxjxdk9xph9xpizwFLgJi/HVG3O5c1zvB2HpxljDhpjvnbePonjA9/Gu1FVj3HIdd71d26WOKouIuHACGCRt2P5PbFCYm4DHDjvfgZ1/IP+eyEiFwNXAsleDqXanD/3twJHgDXGmDrfJqdY4GGgyMtx/K5YITG7ugiJJXorViYijYD3gWhjzAlvx1NdxphCY0x3IBzoLSKXejmkahORG4Ejxpgt3o7l98YKiTkDaHve/XAgy0uxKDeIiD+OpPxvY8wH3o7Hk4wxvwDrscbxgX7Af4nITziGCAeJyNveDen3wQqJORXoJCIdRKQ+cDvwkZdjUuUQEQFeBXYYY2Z7Ox5PEJHmItLUebsBMATY6dWgPMAY85gxJtwYczGOz9V/jDF3ejms34U6n5iNMQXAJOBzHAeSlhljvvduVNUnIkuAzUAXEckQkXHejslD+gFjcPS+tjq3G7wdVDW1AtaJyDYcHYU1xhidWqYumJ6SrZRSPqbO95iVUspqNDErpZSP0cSslFI+RhOzUkr5GE3MSinlYzQxK6WUj9HErJRSPub/AYLMiovPuNHzAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.heatmap(contri_univ.T @ contri_univ, mask=None, annot=True, center=0., linewidths=0.1, cmap=\"coolwarm\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAVQAAAD4CAYAAACzOx6UAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAStElEQVR4nO3de6xlZXnH8e/vnBnkLlqoVUaLWC+12ChSitoQKrRFsRobm2JjL0SdJvWCtonF2oaYWtumVqXpdQpSrQpVxEiUWLReenW4CeUyUGG0MIzA4IWRQoVhnv6xF/Q4PWfvfThr7cua7ydZmX3W3ms9787MPOd517ve9aaqkCSt3cK0GyBJfWFClaSWmFAlqSUmVElqiQlVklqyrusA//OPH5jYbQTXbvjZSYXiseu+ObFYB333GxOJs3PfQycSR1rJU448Mms9x6fWP33snHPKAzeuOd5SVqiS1JLOK1RJmqSsb7XoXBUrVElqiRWqpF5ZWDe9CtWEKqlXsn56HW+7/JLUEitUSb3SZpc/yZuB1wAFXAOcVlX/s2Ls1iJL0gzI+oy9DT1PcjjwRuCYqjoKWAROHXaMCVWSVrYO2C/JOmB/YPuoDw+V5BnAy4DDGZS924GLqmrL2tsqSe1aTZc/yUZg45Jdm6pqE0BV3ZbkXcAtwH3AJVV1ydDYI4L9FnA+EOBS4LLm9XlJzhjWyCSXJ7n8nE9+foyvJUntWE2Xv6o2VdUxS7ZND58neQyDYvLJwBOAA5K8aljsURXqq4EfqaoHvqfBybuB64A/XO6gplGbYLJz+SWpRScBX62qHQBJLgSeD3xwpQNGJdTdDDLzf+2x//HNe5I0U1oc5b8FOC7J/gy6/CcClw87YFRCfRPwj0m+Atza7HsS8EPA69fUVEnqQBbbSahVtTnJBcCVwC7gyzQ975UMTahV9ekkTwOOZTAoFWAbcFlVPdhKqyVpRlXVmcCZ435+5Ch/Ve0GvrSWRknSpCy0VKE+Es6UktQrWfDxfZI096xQJfVKFqdXJ5pQJfXKNK+h2uWXpJZ0XqFOciXSO446bmKxHnvDxROLddejDp9InH347kTiAKQmN4GuMrmKpWoysRInIK5kmoNSdvkl9YpdfknqAStUSb3S1tTTR8IKVZJaYoUqqVey4H2oktQKR/klqSWO8ktSD1ihSuoVnzYlST3wiBNqktOGvPfwqqcX/v3fPtIQkrRqC+sWx97atpYu/9uBc5d7Y+mqp5ff+C0nHUvaKwxNqEn+Y6W3gMe13xxJWptZXgLlccDPAN/aY3+Af+ukRZI0p0Yl1E8CB1bVVXu+keQLXTRIktZiZm/sr6pXD3nvF9tvjiTNL+9DldQrXYzejx17apElqWesUCX1ijOlJKkHrFAl9crMjvK34bHrvtl1iP+LNcGVSPd58L6JxcriZCab7Z5gh2WSK5FOkquR7t2sUCX1yuJ6R/klae5ZoUrqFUf5JakHrFAl9YqrnkpSS+zyS1IPmFAl9UoWMvY28lzJIUkuSHJDki1Jnjfs83b5JfVKy9dQzwI+XVWvSLIPsP+wD4+MnOQZSU5McuAe+09eWzslaXYlORg4HjgHoKrur6pvDztmaEJN8kbgE8AbgGuTvGzJ2+8cctzDq56ed/75YzZfktauxS7/kcAO4NwkX05ydpIDhh0wqsv/WuC5VXVPkiOAC5IcUVVnMVhXallLVz3devPNTm6WNDGr6fIn2QhsXLJrU5O/YJAfjwbeUFWbk5wFnAH87krnG5VQF6vqHoCq+lqSExgk1R9kSEKVpHmwtPhbxjZgW1Vtbn6+gEFCXdGoVH57kmcvCX4P8BLgUOBZ4zRYkiYqGX8boqpuB25N8vRm14nA9cOOGVWh/jKwa48gu4BfTvLXI46VpIlr+cb+NwAfakb4twKnDfvwqFVPtw15718fUfMkaU5U1VXAMeN+3vtQJfWKc/klqSXO5ZekHrBCldQrdvklqSW9XvX0oO9+o+sQD7vrUYdPLNakViIFePyNn5tInNuecdJE4kh9ZYUqqVd6XaFK0kRN8Rqqo/yS1BIrVEm9khFz9LtkQpXUK9O8bcouvyS1xApVUq84yi9JbZnlmVJJjgWqqi5L8kzgZOCGqrq489ZJ0hwZtUjfmcCfAn+Z5A+APwMOBM5I8rYhxz28SN8HPvLxVhssScO0uEjfqo2qUF8BPBt4FHA7sKGqdib5Y2Az8PvLHbR0nZYd11/qIn2S9gqjEuquqnoQuDfJzVW1E6Cq7kuyu/vmSdLqJLN7DfX+JPtX1b3Acx/ameTRgAlV0uyZ4VH+46vquwBVtTSBrgd+pbNWSdIjNLPPQ30omS6z/y7grk5aJElzyvtQJfWKa0pJUg9YoUrqlSwuTi22FaoktcQKVVK/zOoofxt27nto1yEetg/L3pTQid0TLO5dPE+aD1aoknplmk/s9xqqJLXEClVSr2Sdo/ySNPesUCX1yxSfNmWFKkktsUKV1C8z/Pg+SZors/yAaUmaL/P0tKkkH+iiIZI074ZWqEku2nMX8JNJDgGoqpeucNxGYCPAO97xDk595SvX3lJJGkPbT+xPsghcDtxWVS8Z9tlRXf4NwPXA2UAxSKjHAH8y7KClq57evHWrq55KmmenA1uAg0d9cFQqPwa4AngbcHdVfQG4r6q+WFVfXGsrJal1yfjbyFNlA3AKg6JypFFrSu0G3pPko82fd4w6RpKmahVd/qWXJxubmh72Q94LvAU4aJzzjZUcq2ob8PNJTgF2jtdUSZptSy9P7inJS4A7q+qKJCeMc75VVZtV9SngU6s5RpImqr3H970AeGmSFwP7Agcn+WBVvWqlA5x6KqlXsrAw9jZMVb21qjZU1RHAqcDnhiVTMKFKUmscYJLULx1MPW3ucPrCqM+ZUCX1yzxNPZUkLa9XFWpqcpOyaooLgfXBwfftmFisnfsdNrFYmj6fNiVJbbHLL0nzzwpVUr/Y5ZeklkxxfMMuvyS1xApVUr+0/IDp1TChSuqXKV5DtcsvSS2xQpXUL1O8D3VVCTXJTwDHAtdW1SXdNEmS1mBWu/xJLl3y+rXAnzFYCuDMJGcMOW5jksuTXH7+eee11lhJmmWjKtT1S15vBH6qqnYkeRfwJeAPlzvIVU8lTc0U70MdlVAXkjyGQSWbqtoBUFX/nWRX562TpNWa4dumHs1gGekAleQHqur2JAc2+yRJjVHLSB+xwlu7gZe33hpJWqsZ7vIvq6ruBb7aclskae1mdZRfkjQ+b+yX1C9THJSyQpWkllihSuqXhcXphZ5aZEnqmV5VqK5EOj9ciVSd8Yn9kjT/elWhSpKj/JLUA1aoknqlHOWXpPlnhSqpX5zLL0nzzwpVUq9M8350K1RJasnQCjXJjwNbqmpnkv2AM4CjgeuBd1bV3RNooySNb4ZH+d8H3Nu8PovBkih/1Ow7d6WDXPVU0t5o5CJ9VfXQYnzHVNXRzet/SXLVSge56qmkqZnhmVLXJjmteX11kmMAkjwNeKDTlknSFCV5YpLPJ9mS5Lokp486ZlSF+hrgrCS/A9wF/HuSW4Fbm/ckaaa0OMq/C/jNqroyyUHAFUk+U1XXr3TAqFVP7wZ+tTnZkc3nt1XVHW21WJJa1dKN/VX1deDrzevvJNkCHM5gUH5ZY92HWlXfAa5uo5GS1KVaRUJNshHYuGTXpmYMaM/PHQE8B9g87Hze2C9pr7V0AH0lSQ4EPga8qap2DvusCVVSv7Q4UyrJegbJ9ENVdeGozztTSpKWkSTAOQwmN717nGNMqJJ6pbIw9jbCC4BfAl6Y5Kpme/GwA+zyS+qXlrr8VfUvwKpO1quEWjW5p8wkTgDT/7dQuycSZ/cUn/mplfUqoUrSNB8wbUKV1Cs+D1WSesAKVVK/2OWXpHbU6gbmW2WXX5JaYoUqqVdW83CUtplQJfXLFBPq0MhJ3pjkiZNqjCTNs1Gp/PeAzUn+OcmvJzlsnJO6SJ+kaalk7K1to7r8W4HnAicBvwC8PckVwHnAhc2Dp/8fF+mTNC3TvIY6KnJV1e6quqSqXg08AfgL4GQGyVaS1BhVoX5PTVxVDwAXARcl2a+zVknSIzXFqaejEuovrPRGVd3Xclskac1mtstfVf85qYZI0rzzPlRJvTLNqacmVEm9MrNdfknS+KxQJfXLDI/yS9JcqSl2vHuVUF04T9Pm4nnT5xIoktQDvapQJclRfknqAStUSb3imlKS1ANWqJJ6ZffC4tRiW6FKUkusUCX1itdQJakHhlaoSfYBTgW2V9Vnk/wi8HxgC7CpeYK/JM2MWb4P9VzgFOD0JH8H/DywGfgx4OyVDnLVU0l7o1HXUJ9VVT+aZB1wG/CEqnowyQeBq1c6yFVPJU3L7szuKP9C0+0/CNgfeHSz/1HA+i4bJknzZlSFeg5wA7AIvA34aJKtwHHA+R23TZJWbWaXQKmq9yT5++b19iQfAE4C/qaqLp1EAyVpXowcDquq7VW1vXn97aq6wGQqaVZVFsbeRklycpIbk9yU5IxRn/c+VEm9UmTsbZgki8CfAy8Cngm8Mskzhx1jQpXUK5WMvY1wLHBTVW2tqvsZjBu9bNgBJlRJe62l98w328Ylbx8O3Lrk523NvhU5l19Sr1SNP8q/9J75ZSx3oqH31VuhStLytgFPXPLzBmD7sANMqJJ6pVgYexvhMuCpSZ685LkmFw07wC6/pF5p68b+qtqV5PXAPzCY3PS+qrpu2DEmVEm90uZMqaq6GLh43M/b5ZekllihSuoVn9gvST1ghSqpV2b2aVOSNG9Wc2N/2+zyS1JLrFAl9cpMd/mTPAV4OYMpWLuArwDnVdXdHbdNklZtZkf5k7wR+CtgXwYrne7HILH+e5IThhznqqeS9jqpWvnhKUmuAZ7drHS6P3BxVZ2Q5EnAJ6rqOaMCuOqppHE95cgj11xeXnPTHWPnnGf90ONaLWfHuYa6DniQwUqnBwFU1S1JXPVU0syZ5ij/qIR6NnBZki8BxwN/BJDkMOCbHbdNkubKqFVPz0ryWeCHgXdX1Q3N/h0MEqwkzZTdszzK3zyuaugjqyRpVszsKL8kaXze2C+pV2Z5UEqS5opdfknqAStUSb0yzS4/VTWTG7CxT3GMNV+x+vid+hxrVrZZ7vJv7FkcY81XrD5+pz7HmgmznFAlaa6YUCWpJbOcUDf1LI6x5itWH79Tn2PNhKGP75MkjW+WK1RJmismVElqycwl1CQnJ7kxyU1JzugwzvuS3Jnk2q5iLIn1xCSfT7IlyXVJTu8ozr5JLk1ydRPn7V3E2SPmYpIvJ/lkx3G+luSaJFclubzjWIckuSDJDc3f2fM6ivP05vs8tO1M8qaOYr25+TdxbZLzkuzbRZwm1ulNnOu6+j4za9o3wu5xI/AicDNwJLAPcDXwzI5iHQ8cDVw7ge/1eODo5vVBwH928b2AAAc2r9cDm4HjOv5uvwF8GPhkx3G+Bhza9d9VE+v9wGua1/sAh0wg5iJwO/CDHZz7cOCrwH7Nzx8BfrWj73EUcC2wP4OZmJ8FnjqJv7dZ2GatQj0WuKmqtlbV/cD5wMu6CFRV/8SEVh2oqq9X1ZXN6+8AWxj8I287TlXVPc2P65uts1HHJBuAUxis7NALSQ5m8Mv2HICqur+qvj2B0CcCN1fVf3V0/nXAfknWMUh22zuK88PAl6rq3qraBXyRwarJe4VZS6iHA7cu+XkbHSSeaUpyBPAcBtVjF+dfTHIVcCfwmarqJE7jvcBbgN0dxnhIAZckuSJJlzNwjgR2AOc2lzLOTnJAh/EecirQyRLBVXUb8C7gFuDrwN1VdUkXsRhUp8cn+b5mYc8XM1gpea8wawl1uaca9Oa+riQHAh8D3lRVO7uIUVUPVtWzgQ3AsUmO6iJOkpcAd1bVFV2cfxkvqKqjgRcBr0vS1RI86xhcCvrLGqzq+99AZ9fyAZLsA7wU+GhH538Mg57ek4EnAAckeVUXsapqC4O15z4DfJrBZbtdXcSaRbOWULfxvb/NNtBd12SimlViPwZ8qKou7Dpe0039AnByRyFeALw0ydcYXJp5YZIPdhSLqtre/Hkn8HEGl4e6sA3YtqSyv4BBgu3Si4Arq+qOjs5/EvDVqtpRVQ8AFwLP7ygWVXVOVR1dVcczuKz2la5izZpZS6iXAU9N8uTmt/apwEVTbtOaJQmDa3JbqurdHcY5LMkhzev9GPxHuqGLWFX11qraUFVHMPh7+lxVdVL1JDkgyUEPvQZ+mkHXsnVVdTtwa5KnN7tOBK7vItYSr6Sj7n7jFuC4JPs3/xZPZHAdvxNJvr/580nAz9Htd5spM/U81KraleT1wD8wGPV8Xw0WCWxdkvOAE4BDk2wDzqyqc7qIxaCa+yXgmub6JsBvV9XFLcd5PPD+JIsMfll+pKo6vZ1pQh4HfHyQC1gHfLiqPt1hvDcAH2p+qW8FTusqUHOd8aeAX+sqRlVtTnIBcCWD7veX6XZa6MeSfB/wAPC6qvpWh7FmilNPJakls9bll6S5ZUKVpJaYUCWpJSZUSWqJCVWSWmJClaSWmFAlqSX/CxLThQvH3WBtAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.heatmap(contri_biv.T @ contri_biv, mask=None, annot=False, center=0., linewidths=0., cmap=\"coolwarm\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/tmp.KHh4vP4VIF/ipykernel_8248/756916684.py:8: UserWarning: The following kwargs were not used by contour: 'center'\n",
+      "  contour = plt.tricontourf(expl_x1,expl_x2,expl_y, 100, center=0., cmap=\"coolwarm\")\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXIAAAD5CAYAAAA6JL6mAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAABGm0lEQVR4nO29e9Q9V1nn+Xmq6rxvEki4hWsSOsEJYMbmEtMRRVEE7SQ6RNvuHvA6tk5Wekg39IxLcVgLu8c1s7z1BZdoOhPTNi2INzKd1shtBFkuBJJgSAgB/RkY+ZFgDLRAA/7eU+c880dVnXeffXZV7bqdU3Xe/Vmr1ntOnapd+9Rb51tPPfvZzyOqSiAQCASmS7TrDgQCgUCgG0HIA4FAYOIEIQ8EAoGJE4Q8EAgEJk4Q8kAgEJg4QcgDgUBg4iQ+G4nIVcDrgRi4WVV/xvr8WuCngSWQAq9W1T/22dfF4w4P9CmzGclZM+ZfnhMlQnKYEB3MiJIEmc0gitAoQaMYFUElAmSjLRVB8/XK8WvJ362+A4rkoZgq6+2oo117/fHr/FiOqM7jZtePa/6tOo59DPM47r6sH2PteFZfXNts7OMZqmqfv7XPSs5lZXse53njHOnan+PPja9gr7O/Xtl6E/urVnz1xvtt/B98tnEeLPvz6LP2z2676667HlHVJ3Zp42vjR+kXdOG17Sk983ZVvarL8YZA6uLIRSQG/gz4NuA0cAfwClX9qLHNo4EvqaqKyHOA31LVZ/vs6+JrHnee/uqzv5onPuuJPPThhzj78WfzhK86n3Of/mQOn3g+8ROfBI8+j8WjH8P87MeyjGfMZ+ewiGYbbaXRjEU0Y0HMgoRUs3tXIikxKQAxC+LlnGQ5X+1jYre7IDZeZ+0V7S40zt/H2CSSXSyxLIx1RR/S1bqYhdcxzOOky8RYt/6DTWR5/DpKnX0p+mH2JSbfJj8vxfmpwz5/Jq7/Eayf083PzO/mPs/F9y++e7rM/i7yv/Nlvt3iWOqKbY7ydenqL2vv58enZoOZZQol8ebvKYnrtzlw7Rct1987tplF6wIUW/vY7XzDV5+78fmUEZG7VPWKLm1cGp2lrz/rYq9tv+MrH+98vCHwuUVfCZxS1QdU9Qh4C3CtuYGq/jc9viM8imNDqHbfKuKDxHjtFoDIU1xcLPweSDYoBG4btO1jIODiffd/cdddCAyAj5BfAHzKeH86X7eGiHy3iHwM+H3gnzTZtw+iZYXZ5KCw7DbW11jjY8e2xsfE1M7lvvLe+7606y6MComF2bmJ1zJWfH71LrfbxjOeqt6qqs8GvovMX+69L4CIXCcid4rInZ87c7Ran5yVkBxu5wRWuQT6ZOFwu5iWd5WbIRDogyDm+4WPkJ8GLjLeXwg8WLaxqr4X+CoROb/Jvqp6k6peoapXPP7wwKNb7XEJad8ksj33Sx1jttLrCK6l4Qhivj/4/EruAC4VkUuATwMvB77X3EBE/jvgL/LBzsuBA+CzwN/U7VuF6RePD+ut5djyl3d9lHcNcpb5xxNJSTUhlsVWbhR9k2qyNuDp3Caa1Q54DvlUU+YO20fsgc6heO99X+JF//2jtnKssSKJcPB4z2vr4WH70pZaU01VU+AG4O3A/WQRKfeJyPUicn2+2fcAHxGRu4E3AP+jZjj3HeB7OLGFvde2i4gOmvnm+8QVGRMINCVY5tPH6zakqrcDt1vrbjRe/yzws777NmF2zozksFqwosWcRTysO2bKmOGHY2SbYwJJrGshiIGMYJlPm1E7T33cKXX4xj5vuFEqYscDgX3kpFrmIkJyVuy1jJVRC/m2CCI9PPsYemhPBgoEdkUQ8gE4ni3ZX+TKSRroC+yOk2qVT53Rq0NymKzN8OybBcnGgGVTt0pMyoJkFbkS6IcQeliNPT2/L06av1yibL7KlBm1RT6kgEN3K3ebU/V9sQc2xz7Q2YYphndOjWCZT4tp34YM4sURy2jcXyfVeMPd4hO/PRW2NTM2sB1OimUukTA7Z9rX7qgt8oLZ2f2f5DKrborRKmbmw6bs2rqdwvntgp35cGoEy3wajF7I62LITZomzrIZIrJiF1P1y9wpRQrbpuxDxMlQ/uSTwLvv/cquuzApRCQWkT8Vkd9zfPYYEfkvIvJhEblPRH64j2OOWsijWXMBiZbpatkl6znHF6PKvbJt9uFGcNLZZzEXyQrX+CyevIpsJruLVwIfVdXnAt8C/GsR6TybcdRCvmuaPPYXkS9V/u5ti/k+DnQGdsc+i3lfiMiFwHcAN5dsosC5IiLAo4HPQfc8H6MX8vigPvywS3GJfWXqIh5CD8dJEPNa/h3w42RlL138EvDVZFlg7wVepaqdf6yjF/JtMZVBt10PTo6JkDRsN+ybmEskJIex1wKcX9RNyJfrVu2IfCfwsKreVXG4vw/cDTwNeB7wSyJyXtfvcCLMnng5ZxE1+9FPRdh9aTvQGRgeV73OwGh5pKJm5wuBl4nINcBZwHki8uuq+v3GNj8M/ExeGvOUiHwCeDbwwS6dChY503+Mn6pI79vN8iSxb1Z5H6jqT6rqhap6MVnthT+0RBzgL4GXAIjIk4FnAQ90PfboFWx29qy08HIfuCbkdBWYqReZCAR8ePe9X+HFf/fsXXejOyKDziIv6jbkqb9/Gvg1EbmXrBTmT6jqI12PMXohr0MWKRqP42sUOVf6YqgnhZMUChlHSxbL8OA5FHsj5j2jqu8B3pO/Nms3PAh8e9/H25srPFpsRq7UxZLv0lquK8DclCHcK8H1EfBh6m4WiYTZ2TOvZayMWsiX8+5hhU3LvdniNXX/OezWh95mMtA+nPOTxtTFfOqMWsghjyP3rBQUL46IF0etjxUs0PFSlamyKtdMcKtsjyDmu2Mvr/IuYt438UD+aFcMdRvLe6j+BU4mUxRzkeOJh3XLWNlLIe+LTj5rIxImlsVoBHOogc6mKWzD08/+8o4Pj8eQOikEIe8Zu9rQ2mc7EPSpxphPkSRM7FkRxHy7jF7I44PZqB9p2jCkmAfhDoyFyYi5RLnO1C9jZfRCvi1sN8rQkRNNxNw10NeHi2Qs7p7A/jIZMZ84QcgJFeoDgcC02VshtyNXygolT3kKfZlVXuZemcKMzronoar/V6rll/N8Od3/89QZu1UukRAfzryWsTJ6IY8PZ60qBXWhq1vFp8iEyVBPBK1Lu4UJOYNxUgdExy7mU2f0Qu5LKC6xTlMR973pBAJtCWI+HHsh5LI4uSLU1l0SBjr9mYUHlN4Yo5iHCUEjI1rMncmzmhDcCoHAsIxRzPtCRM4SkQ+KyIdF5D4R+VeObb5PRO7Jl/eJyHO7HtdLyEXkKhH5uIicEpHXNOmYiHxSRO4VkbtF5M6mHezjLph4ul32WcSbWO5Vk5r6IMzqDIxKzEWIZjOvxYMzwLeq6nPJSrldJSIvsLb5BPDNqvocsvzkN3X9CrVCLiIx8AbgauAy4BUiclnDjr1YVZ9XUSJpb9mG73kK0Sh9E+p1Tp9RiXlPaMZ/y9/O8kWtbd6nqv81f/t+4MKux/WxyK8ETqnqA6p6BLwFuHbojk0d06pNJB31YOJQfWuawravJ6K0IuNhupBejhHoh30UcxGJReRu4GHgnar6gYrNfwT4g67H9BHyC4BPGe9P5+vKsDumwDtE5C6z4vRJZCxiHgY6A2Ni52IuQnSQeC3A+SJyp7FsaJqqLlT1eWQG7ZUi8jXuw8qLyfTyJ7p+BR8TyGXCOINhjY59o7H6har6oIg8CXiniHxMVd/r2Pc64DqAp559uFrfJoY8WsxZxjPixRHLyM/Kc9XuHILiGH3HjieyKHU3nETXS2Ba3P6hOddcPt4JNwaP+LqIVfVvROQ9wFXAR8zPROQ5wM3A1ar62a6d8rHITwMXGe8vBB60NzI6dq3ZsbxGHar6MHArmatmA1W9SVWvUNUrHn944P8Naqgr9wa7md3Z1t0ytDXdZqCzaQrbqVA1eSeEJAZciMgTReSx+euzgZcCH7O2eTrwVuAHVPXP+jiuj5DfAVwqIpeIyAHwcuA2n46JyKNE5NziNVnR0bU700nHFvTCT7ytCJqmN5NdiHbIhXMyuP1Du5nUJyLEhwdeiwdPBd4tIveQaec7VfX3ROR6Ebk+3+Z1wBOAX24bzWdT+wtR1VREbgDeDsTALap6X9GpvEK02TGANH/8eDJwa74uAd6sqm/r2um2xKSkHgK5LTdLW2JZOJ8iqtwrgcAUmJCLxYmq3gM837H+RuP1jwI/2udxvUwdVb0duL1px1T1AaBTsHt0kLA8Gq+oVhGTji42vYlrpizR2JioqtcZmCZTF/NdsFczOwObA5sneaCzqvByVYhiYPds1c0igsxmXstY2auruY/EWVPxxw4x6Dn0jM5AoAm78plPkdELuecAQy+Js6Yi4n0x5nGAQACCmPsyeiEPNKfMnTLmiUBjG0sIjIehxVxEiGaJ1zJW9k7IC/eKnQUx3lG+8iHdFUMK8xQGOgMnh2CZV7N3Qj5GYtJOgt7WBTKmjIcFTTMfnjR3V6CcwcRcBElmXstYGb2Qj3mkuCnbHEzcx2iVtvU6A/tDsMzdhKt/y3S1zjfaaynYJ2mgs6rw8lFFNsSQKTEwFYKQ74gqQXcN/HUV3i7+9DbjC01T2AYCvvRulUeCHB54LWPlRAj5rgY6fRhj7HYY6AyMndvuDNeoyYkQ8rHj624ps8q7Rq+M8WYSCNQRxPyYExcSkEi6MWg2lvjqbeVm6eKmseuf7msK2z5IesxfVpVSt3Fb0bJRioI4WlamO7CZRYvKcYk+aPodKsmjVqbMaIV8dk77Exst5yyj2SqWvKy4RFcBH1MR4bKMiJ3bHbFbale45oX4CK1rmwPHuiRa1vch2rx2Y8d+ZW0V633FsGjbV9DN/vmIunlufAeZfc7TSWGvXCt10/QL328si04iviAeVMSrXB1jK0ZhW+j7jq+I29Z4FxG39+0q4vY2xeJDHC1Xiy+zaOHsc2mfYu31CWSbiMgtIvKwiJTWXRCRb8nzkN8nIn/Ux3FHa5H3TbKc9xJJMSYrfAjCQGczpiziZfsMbaX7ul3aWOltEBGkv+n3vwb8EvDGkmM9Fvhl4CpV/cu8BGZnxmmRS7//NJ9ybzbmjMJt5gEprPE2A5BtLO8w0NmeKYl4Iv7C3sRCL/rQxEovLPR9tNLzesSfq9jke4G3qupf5ts/3MdxT4xFXuCqEmS6K6YwJTyRtHU/+xzoPMlMUcRNMfeZCWu2NSYrvXfrXCKYHdZvl3G+VZrtJlW9qcHRngnM8qLM5wKvV1Wn9d6E0apWctiua7JI0ThZG/BcxFkgf7ycs4iyC2YKMxv7iGLZ9kQgc9+TNCnIJ0KlrYi76GqJF+t9Uxu0dbuAn6g3GRwdRMz9eSQvY9mWBPha4CXA2cCfiMj7uxZhHqWQSzTsP2kKIt6WLtErU/GPj60uqUvEbTHuIuK2Nd6nO2UfrPSJcZrsZvAl4Esi8l6ycpidhHycPvIB2Lcwun2+GU2dqYi4a59t+NJ9qfKj9+4vTxK/pTv/GfgmEUlE5Bzg64D7uzY6Sou8b+LFUWks+Wobhxsj1WQlmAuSnQwMDjlJaDffZ7FXkT91fvGxiHgSpd6Fqtu6XcDPSm/jdpmKdS4ivwF8C5kv/TTwU8AMsoL1qnq/iLwNuAdYAjerammooi+jFPKeg1bWyIQkMd73L2a7Ev2CMvfKSbDid1lUecwibv4FvES9qdvF7NNQbpe1Y40wikVVX+Gxzc8DP9/ncUcp5F2xBzwLzFjyoYR2COu5zCqvi17Z1UBnwE1bEfduq0LEy9YPbaX3NTg6qFUuAhOfoj9aH3ly2O8/zYwlH8oKH1PdyaYivuuBzm08wWwz0sG2xruIuG2NdxVxexuf7czjNPGlN505Cu6nD/C7wZ1UxinkMp5u1U0M2rWAt3WXhIlAwzEVEbe3byvq/sdolgog4M94TMgBKYslLyis0aaCvO0Zn2Oy+PeNoaz1sYh4IgvvsM22bhcYLoSxYBAXyx64VvZGGTROapNm2bR1J0xRUJtY7sE/PhxtRdzZVgMRN/+CXyx+08FRs099+NKbps89yYzyLPUxIagQ9cgQpUKg4jx/YRvGKOLbiEYJ0/ObY1vQXUR8o62GIu5a36RA9zbcLr4EX/km41OlnPigXdei9AzLZDNvgm8sOZL5xRcarwYMzXjyXTKUe2XXA51jYOhp32MScdc2Td0u0H8Io6tYxDascpUInY23HqcPo7TIA8MSBjq3y1hF3N5+bFZ6FcEqX8dLyEXkKhH5uIicEpHXOD7/PhG5J1/eJyLP9d3XfTz/L9AU20UQL+d74ROuemIYw9NE4JhdiHiTcNS2gu4r6lWC7nKxDB7BIoLGM69lrNQKuYjEwBuAq4HLgFeIyGXWZp8AvllVnwP8NHBTg3030J4nbBV+8rVY8okK+NDW9BTPyZTot7pPMxEvKmP5ivrQVnoT69x1joJVfoyPRX4lcEpVH1DVI+AtwLXmBqr6PlX9r/nb9wMX+u47BFF6Bigv/eYjVkPVwBwbwT++PfosDNHVEm9a7nAoQXc/ZYQY8qb4CPkFwKeM96fzdWX8CPAHLfddMTu738eYohBzW6ZScGInxw1WfCt2JeL2Nm0E3VfU20w0KmM4F4ugSeK1jBWfnrk81k7nh4i8mEzIv7HFvtcB1wFc8OhzPLrVjng5J514wYMu0SthoHMcjEHEy7b3fRJtE/HiinRJZLkR0eKKYAmU43OmTgMXGe8vBB60NxKR5wA3A9eq6meb7Augqjep6hWqesXjz/Yuu9SZfbMmbas8DHRuh66Z+IYW8UYTwgZ0u3S1zKcwdd8jOERE5Bfzz+8Rkcu7HtNHyO8ALhWRS0TkAHg5cJvVsacDbwV+wCpZVLvvNokXR0Am3sVSvO/Ktl0vQ1jWfQ90hoFTP9pX92km4omkrQR9yMHR43136CsXYZkcei31TXkFeFwNXJov1wG/0vUr1Aq5qqbADcDbySpZ/Jaq3ici14vI9flmrwOeAPyyiNxdFCct27e2V9rsH6jxpojaA55RS1ExHzNdYp1qMgn/uYsw0FnNNvJdt82f0sUSLwR9V1b6nlvlPgEe1wJv1Iz3A48Vkad2OaiXAqnq7cDt1robjdc/Cvyo775jx6dK/ZjFu6z/Y/aPjzH1wS4YWsTLtvG9npv60hsl69oPX7krwOPrPLa5AHio7UFH++tpO0W/jmiZdqruvg0B9y2HFjIi7hfbFvGy7ZuKep2gu8S8Sek557F7nLqvIs6n+hLOLzwOOTep6k3Ge58AD+8gEF9OlAqY6Wzh2Ie7iGbO9La7pI/almGgc5w4I1Za5hT3FfEmN/22VnrTeRcuMZ+AVf6Iql5R8blPgId3EIgvozk7Jn3P7LQnBvnO6mx7gXahL7/1Poj4mN1XQ+MTodJExIu/TdxrTX3pVYOjbQZA1/bfxdT9dvgEeNwG/GAevfIC4POq2tqtAntukZdlQtwn2rpXwkDneBlCxMvWDWWl++JrlQ+LrNX27YKqpiJSBHjEwC1FcEj++Y1kY4bXAKeALwM/3PW4oxfyaLbNKjyLUfmc+3CvHLfV3kLft1j7MTO0iJdt01TQoVrUXSkumgx8Oo89LhdLKR7BIQq8ss9jjke1DHSpxAfDzL6sy0u+ywHEXVrJIeZ7nAwp4mXbb9tK37VVriIsR5zZ0Ifx395aIOnmRSyLdC2WPFqma9kQx4qPuI85rDDQHr/CEL7uFH8joY0v3dnOlnzlgT0V8jraCPhJyIQYGA8+YYZNRbxpicNC0H1EvevgutulFETbl1G6VvoMW2k74OkzKahPurpVmriEwkDn9Ogq4mXrfMdgmvrSV/tNwlcua2HJU2T0Frkk7XxXLvcKbKaz3Rf3SvX+4/+O22AbU+6HoE8Rd23Tl9slWOW7Y7RCHh9Oe/AhEOiDIUXc3r6JqDcxDrr6ykPxiXrG6VoZCFmkEM1WWRCBRo9UC40b53n2wddyqnsMDlP2Tx7e7pTl3Ds1RbF/m+utiUtyiKn7bVCRyki2KTBKi1yX/T4CF5kQ21Am3AuNJzkAGvzjw3IwoPvGtsabiHjxt0mYaVMrvayf0LzQxWabwSqvYpRC3oSqZDdlfnKbJhf3VAU8sF80FXF7XVtR9+lHE1wulj7Kwp00pv080YJoOa8N/t+mi6LZQFNz98q2BjqTPSihNxW6iHjZNl0ygrpwuVi6FjQfbpKQ9P79t80oLXI1wg/lcNphQYHA0LQVcXt7Hys9WOXjZJRCDsPlI4csBNEOQ5xKPpHg494f+vDx+op4k+u7qduljG35ygMnyLUyxkyIQ4lymWso3AT2i6YiXvz1dYGVRbq4XHxd3ZG7jGBRkcm7BUdpkfcZteI74Oli6jm9w0SgeoaMMtk2vpa4XXy8aZtNCFb5MSLyj0TkPhFZikhpcQoReayI/I6IfExE7heRr69r+8RY5AVFLPmU6TO9bWA/aOtOaWqlr47X0Sr3nbq/DatctzfY+RHgHwD/vma71wNvU9V/mBenOKeu4dEKeTSbsZzPW0/Rb0O8nEPkn3+i07EGdnMEa3y/qHo67OoTt7e3Rb3ZZKJuk4ScfRtF8YnuqOr9ACKukp0ZInIe8CLgf8r3OQKOSnfIGfWZiGb9ingxMShazrNlMY0BThfb8ndPZRA4cIzrf9bVReKMR++aA2iANLd7wDOAvwb+g4j8qYjcLCKPqttplEKuPbjAxBDpLn5y6O7TGzuhqMT+UCXivtEoXW/erqfBsSfUOp7DWr0A54vIncZyndmOiLxLRD7iWK717EoCXA78iqo+H/gS8BqfnUZJdJCwPNpP98AuokdCxEp3tlh1sBW+lri5rolv2OVi6TpeM0Sa24F5RFVLBypV9aUd2z8NnFbVD+TvfwcPIR+lRW4TtYwplw6uE5dVMbaLK4hzoArfmZ19+Ng32t2SVb5vqOpngE+JyLPyVS8BPlq33yiFfG1mZ89mUJSeySJXcsxMiHUE/11gKgzlLttHX7kiLEi8li6IyHeLyGng64HfF5G35+ufJiJmseZ/BrxJRO4Bngf8X3Vtj/ZhMR7p1PxU404XmVfK2oYpR0MoYr8kMaQTvme3EXHXNdc1f862IlimgqreCtzqWP8gcI3x/m6g1H3jYpQW+RB0HfDcFubAVGC6jCnFalFovK+C4/tolU+dUQq5pj3O7PTwk1dd3FOf3Rk42biu7bLrfYy+8m0k1FKEVBOvZayMUsgBxIghN90sJykboq9VHgY9jxmTJTxmulrmXa3yIabun2S8hFxErhKRj4vIKRHZCIURkWeLyJ+IyBkR+THrs0+KyL0icreI3NlXx7tQVzFouGRW1e0Gd0pg13TOnDjJNLeyKhhTt4yV2mcFEYmBNwDfRhbjeIeI3KaqZkjM54B/DnxXSTMvVtVHfDulC8O1MusvY6GkKZq0ezzqmhR/aMKg53TZVRKoaJl616p0DXw2GZR3tjlA8YmTio9FfiVwSlUfyOf9vwVYm6Wkqg+r6h1AbyZlNEvKI1eSBJ0ddEpLK4uUyLA04jwbnGmRFJaE+Rg41gGYMhGvqrlYNdOvKjteX/mqp0qSZ0xMPPSm2HYW1V83PlZmcU36PDX6uE9c23Sezj9Jq3za+Aj5BcCnjPen83W+KPAOEbnLns7ahLJCE2ZMeBvK8q0UF6N5AXb14RnTfN2fR7OVhWO+9mnXxTYF3BWmtovyWemy+7CPK/SwajpDIdY+KXHj3Idf5csvRMvneiv+H9vIiTNEDpcx+MpVs7Bin2Ws+Fz1rlRdTcJKXqiqlwNXA68UkRc5DyJyXZG/4PMsWM4d/+AeBzpNP3m8OFqzTFYhgIYQ9hm9UucCaSLgTd0pVT+8KjHoywJ39dc10cJ+5HY9bvcRT3y0KM9E5yLxEOtCpL22lULY6yOnfKza4v/UZDBzylZ5IMNHyE8DFxnvLwQe9D1AHuyOqj5MFgx/Zcl2N6nqFap6xWMcP/aqTIhtrXJ7v9iwRl0ulj5pI8Jd9h3CCp+aeyVtKNpVFG4VH7Eu3CqxR0SNjzW+elrcwfnfV6t86vgI+R3ApSJySZ7k/OXAbT6Ni8ijROTc4jXw7WTJ1VsjyQySGRq3f2w3Jwe50tkmayK+bpX3fYE1EeQmAm72u28B72tiyZAsenCxNKFwq/iEP64sdo9BTh9r3GV8NOUkW+WKkC4Tr2Ws1PZMVVMRuQF4OxADt6jqfSJyff75jSLyFOBO4DxgKSKvBi4DzgduzROpJ8CbVfVtbToaHSRrseU2Ta1ySVMwBkvNnCuFa8MclW9U/cRxsS5ISi/iQpzLfNq+4l30r+7H0taFUvZjd7mCnOs83SpN6aPAQJm1nsS6+mzoQU4fkdqlNV7QNYLFd+p+iGDxx+tXpKq3A7db6240Xn+GzOVi8wXguV06OCRReoYlOEu/mRdrEdoXk5J2EJ4qMc8+j9fEvKmAZ33ddBeZ9Cnidrt9FbCtmkHXx4BT0wHRMvdJ34Ocq21zQfcZl+lzkNMVjthIoEOa250xymcFiTeto2KgU2ZJ5lppGQ/uoghDXMTZMdYs8fx1X3HadVZzM1dLs3NQ5UYpo0rAm8Qh74r5st8ffJU13vcgZ0GTkMMhmEpCrbZkU/RHO8ndi0n1Puo5pa2dSMuOXinzPfbhJ+/iUmiTUrNskKqNHzxeHK25ouw2dhF2CP2EHkIz10mVNd73IGfBkG6VXU/dd7a5Jwm1ROSnReSefJb7O0TkaY5tLhKRd4vI/SJyn4i8yqftSQn5ENj5yQvK4nNXg0/WhdQmPLGpIPtuX+dH7UvAi+0Lqh7z24Ydwm5CD33EfG17D2u870HObTLGhFoT5OdV9Tmq+jzg94DXObZJgf9NVb8aeAFZyPZldQ1PQshlNjse6JwdorPjePK6vCmlbVqRKuYsz0Kc1kIQXZZGT1ZBnTj3kdTehyprrK4AR9252jVtQg+TeF3Q24QcVrY/0kHOE2eVa/Y057N0OozqF4y3j8IxH0dVH1LVD+Wvvwjcj8cEzHE7OA2iWZKFHuaY0/Oj9Eyr6forMc/3LcIQF/HBmv+3z4G8Msp8500EvMx6S2pEtq2Ax4uj1bjCmOg79LCs0IRPyOFQg5y7YN995dtARP5P4AeBzwMvrtn2YuD5wAeqtoOJWOR9+8Y32res+jL/bx+DTXUXaNPSUmXt+VhuTd0oq/0W67H3de6VocIOoZ/QQ8is7Eq3SE8hh1MZ5JyKVd4HSnbz91mA84sZ6PmylnZERN4lIh9xLNcCqOprVfUi4E3ADWV9EpFHA78LvNqy5J1M5rYnyawyF3kTq1yTZMO1Iot0dVdb5pONCqs8tqyOrhZDsW8Xy6vN8WOH+2hjmwoL3JWXxrTKXdE+Tajzj28j9NCMGy/7HHaTV2UMBKucR1S1tAybqr7Us503A78P/JT9gYjMyET8Tar6Vp/GJmGRmy4VkgSNZ2i8+U9u4y8vqyBUCFoheKsIlh4Hn9pcqHWVSmyrp1Eu6YYivva556DnNmkbelhnna9tu8O8KkOza6t836bui8ilxtuXAR9zbCPArwL3q+q/8W17EkIOWWWgNUHvo815JlySpms3gUK0qoStLz+mbwmpegFv358mbhT7s8p2tyjobQai6qxqW5x3kVdljIyx+EQXFGG+jL2WjvxM7ma5hyxdyasARORpIlJMuHwh8APAt+ZhineLyDUl7a0Y5bOLiz5EvG4SUeFeWUYzosV85WIpo8/Hv1QT582hr/bL3CpVAl5GEeGzLNwoJe6V1TGsyVRdwg6hn9DDgkLMy0IRC/E23S27zKuybULxif5Q1e8pWf8gcE3++o9xZ5ytZBIWuQw4q1PmR5WhiOYkIacl0mOEgWl1+1rqzsfPDjmqKy3w5Xzt3BTbH38+PvcK+IUeNrXOXZ/1HXI4FqaSUOskMwkhh1zEh2w/d6+Yk4PqXAcFzaqC12+7rUGejck9Hla4T1u7jCmvCz2ssqIPYq0V9F3mVZkCU0xzq5rd7H2WsTIJIV+5VXqo31lEttSlwa0SrjaWgzMjYsvHw7L9qioCFZQNYDWxws3PqnClA/Z1q/jQNvSwTmB9xHqovCpjJVjl42YSQg4ci7jDV27nTGmK7V5xWeV21SCvai0eI/RNxLyskrdzqnODH5lLxKsEXBZp6ZNL3Q/e94dqf8++s90l0bKxdb6LvCpTZIpW+dSZhJBnvvF8AWe8eGsxTw0Bt6NX6twJPYp5laDXfd6G0kHOBgJebO9qc9fT9H0jDNpY533nVZkK+2qVZ4Ulhp+iPyTj7ZmLnsMPV6SbF6MpWIVAOS2NHi86W6zrBLxqoNP1vi4uuOrGVVe4w2fQc6gZij6TfOpEt4vv3Mcan+IgZxe2ZZUHMqYh5LNDLxGXNG1tmRcx5XA8sahNLdCuwl6Id1MLvK1I1g3ouqxw87PKPpUMeprnqEnYIXQLPazzZzcJJ/TZZp+s8YJ9tcqnzjSEvCCZobMD56zOPpDFfHUjqJolal94277o2vgGfWLHTaoEPErPlLqgXG1vwyr3pat1brYDzUIO9xnfSUJNRH9baW5Vs3kEPstYmY6QD+VWcWAXZ87+rseS71rMq47bphivKca+Am5vWzfoaTLE+TJDD+sEtg/r3KRJXpWps+up+4FNpiHkSZJZ4rN+U6autZfOnZODmtBWnHwiMoaoUegbJw/1eWx8Bj37HAD1CT2cRYvqTIQNrfOTFnLYlKkWnwhx5DtA49lqanhvuAY7PXztfVoRqcZOsS5b7zPQWdDUrbK2r8MKNz+r3Ndj0NP+Hs5qQB1vYkNZ501CDveNYJWPi2kIeTLLMx4O6F4xwxBzS7UQKjuW3KTvi68Q7jIBd/nHnYNFPbhVyoTaHlRuMhu2TUy5L1WC2od1Xsc+D3L6MlWrfOqMVshdxST6zLHiJHev1LER4jdBS6KJW6XAFRXkM+hZdwPslJfdCj2ss447W+cNBjn3nX2yytOF3zJWRivkaxiJslxiLot5J9/2RnuGr7ywNmtrVg58AboGynxmdLZ1q2wMata4mnwGPdtYZuZTiW/oYRwtB7XO7WNB88HRfSZY5dtnGkJONpuzWMqoEnMvaz6dO/3lJlURIZO0zD2iVcpEvE7cfQY9h4z26ds6bzLIeVLYJ6t8W4jIj4mIisj5JZ//CxG5L89d/hsiclZdm5MQ8ibRKj7W+drNoAhrbDGRaFcXYZOBThdN3CousbbPcZO0Br6Dnr7UxX0PYZ2f5EFOX6ZUfGKbUSsichHwbcBflnx+AfDPgStU9WuAGHh5XbuTEHIAjZPVMji5Vb6aHGTFkpv0GlK3TFbuA/P16lgNBzqbuFW8BjkdN0mfQc8mibTaJkKqc20M6Ts/6W6VJlb5EFP3J8a/BX6crOZzGQlwtogkwDnAg3WNTkLIi2iV3sMObdK01rXiou/Bzz4r4FRRZz2b1D3ltB30NLGt8rKww7IY8qGt82Kboq3AMWHqfj0i8jLg06r64bJtVPXTwC+QWewPAZ9X1XfUtT2ZUm+FiHcR8yr/ehN8Slr16WJpO9DpoqtbZe3zxbwyJNQsl2eWDDPPn10GzodElpUTgpJoWZlIK46WlQUoZtGij/qMgRKGKAnXBVWY+98fzheRO433N6nqTcUbEXkX8BTHfq8F/neyWp2liMjjgGuBS4C/AX5bRL5fVX+9ar9JCLkmybEg9BidUoXMj9B4RpSeYREnRIs5i/hgdcG5LsZd4bJ8+narrG2fh2gWYxeSpqvBZFmkle4v8we79pp0VXTCpyZjMahYZZ1DeWbEwqIuE/TC8jYFPYQcVuOq79lVoF03evNa2QGPqOoVZR+q6ktd60Xk75KJ84dFBOBC4EMicqWqfsbY9KXAJ1T1r/P93gp8A1Ap5F6uFRG5SkQ+LiKnROQ1js+fLSJ/IiJnROTHmuzrg2lJ1xVE7kyDQU/bAu6cptOazu2a3t1XyFVbt4odZ+8z6NkkkZb5/Xxyk9RFifThOw8C3j9j8pUruVfVY2l9DNV7VfVJqnqxql4MnAYut0QcMpfKC0TkHMkU/yXA/XXt1wq5iMTAG4CrgcuAV4jIZdZmnyMbaf2FFvt6sYgPVpXau1BYi2vhiEXkyjwXomKw0yOWvG8xL6PtjE6zz326Vaq27yORVpNBz0SWlYLe1XcOwRr3JfjKmyMiTxOR2wFU9QPA7wAfAu4l0+ibKnYH/CzyK4FTqvqAqh4BbyHz4axQ1YdV9Q7A/o/V7uuD+ajeh5h3xb4wXWIeOyzO4uIrrM7jwrsV4W89+scLmk7JX21rW+P5+6ZWeXFuEuM8+VjlSZSuFheFoJeJeiHoZaJeCHoYyNwOY7LKt01umT+Sv35QVa8xPvspVX22qn6Nqv6Aqtb6O32E/ALgU8b70/k6H1rtK0kWrymz2XF5tyjZ8L91Yc3iNCNVbKu8JATRFutkOa+0zn3FfFVJJko3ajsmkq72X7VnHNcOO6yzxstEfN26zs9DSeoCc72Zy71oO1rOj3PVLI420gFvvDbOT9WNzhR1twtqWSnspqi7hN0U9SDszZiaVZ7FkavXMlZ8hNwVBe/7jbz3FZHrROROEbnz84sFUrg7BshDvmZ5usINc0EqRMpOnmVSJ+ixw+r0EfMuIh4vjkpFvLgh9SHiq+3MlAY1LhZbzM3+uwpbm+fGXGxsYd8Yb7CE3RZ3W9htcQ+C3p0hik8EMnyE/DRwkfH+QjwC1Jvuq6o3qeoVqnrF48+aIYcHWeKspFva2tYZEyv85NEy3bA6fAQd/MS8q4ibuER87fMaEV/DTmFgvLfF3CyXt3qacfjLq8TcPDe2z9wW9m1Z7UHQ/QhT97eLj6/iDuBSEbkE+DTZdNHv9Wy/1b4igiQzJC/tBqxCmLpeIKaVuGZpzs+sv06STKRmB5nAJYdEy/la1IzZl8LtU1yARX8LkUqj2SoUqwipWlme1nPLQuNBRXzl9vAQ8dU5qpoolc5XT05FbLmkKRFZxJEs8tfRbNWnRXxQG1sek4Ic1/W0xdwOUbTF3J5Q5BJzc/KVS8zN8Ma6kMZAPa5wxF2H8jaMIx8ltUKuqqmI3AC8nWze/y2qep+IXJ9/fqOIPAW4EzgPWIrIq4HLVPULrn3rjimRILMEOTzoJQd5WcbEFa4IjTSFZOaMJy8wB14LUTcF3bxgNx4hcy0oBGtBQiIpqSadRNzl/qlLjFUr4j6kc4QsttycKBSlZ2rFHFjF5hevzfhhc/DTLNbsimwxxd1lpdeJuz2r1hT3QtTrJhwFMlxx5U1wiX6bCWQnAa+zrKq3A7db6240Xn+GzG3itW8dEkcwO0TmKcoWYscNNL81y+xwZWnKYo4mSSaC5uzNXDzLBL3K+nBZ56aYm+JlivhqnSOfShMRX7k+fETcN22BJeaQ3UQLMS/6U7jK4sVRrZgDa5M/NqfxV+ej6Wq1uyz2VKMg5h0Yo1U+dUY5s1MESBJklrA0rOk0mjHjK63aNCcVlUasmFS4V1ZtxseCVFCIemGN2L4+c1ZolZhD5ie2RdwM2TOjU9qIuElnETfbmh+5xZwslLTo1zKercS8+I5lYm5SJezQr9VuCnsh6kWKgJOeLMuHKVjlqjCfjzcixYdxmhQSZT7X2XH+8TZ3a5dbpjZixaQkemXV1mK+IaBmxEhVGJbtHrEHQduKeLScr5aCugiVPkXcHPy0j9MlLNEkOzfHi00i6dqysX8+eOoaRM32dw+gmoOmdZOQAtUMUXziJDNKIY/ifPQv2Uxb63t3d4l4kxS4hYvFFb1iC6VL0E2KKBdbrKrEvKmI230q8AkzXK3zFfHaG6A7ksXuU5WY25Es9mJiC7st7raw2+JeJeyuyBjTSg9iXk+IYBmeUQo5IplFnoce1s3mtAszlw2QekWsmJRMDiqoEvQyq9xHzNuIeN33bRQr3sYSt/EIS1z1zSMs0aZK2LPP21vtdcIOm9Z5oDlDFJ9ogyqkqXotY2W0Qq6zg0zIc1FeRLPaLGq2oPeCw70ii3RdiByCDmyEA9ribgp1IdaxJV5tRHyjf01jxfvCaMsnxtx181uzzK1zZNK31b62ryXqdtqAbF1wtVQRik8MyzgHO6Moi0WeZwNhfU7NB4/Qwxydp87oleN2sn0Ll81qEC8PsXMNhpallLUHQWH9gq4S8bJam9AhVrx43WZmrblvj2GJ5jiJ64ftGhRb+9yRDnX9c/cgqj14utB4Jeapxisx31ZBkKkyRJrbPlCUNJ32TXiUFrmIoEmCzjZFvOs/3StiBdDiM4d7ZaPCvMNCLygT7irr3PwbL+fu3CnbEPEqmmyTztcSbJmDn6u+Os5ZtEyds2VdeW2gX6vdxLbU66zzQHeCVd6MUQo5IiyTQzSeeblUqnBNBvLedyVEmz/QKD2zWgo2BN1yXRQ+9DI/ustvbot4tJj3L+ImfbpWzPYqxLxs8LOgTJxtYS/LQukr7uvry0V9tY0jrUIQ82qGrns7dkTkn+X1Ge4TkZ+r2C4WkT8Vkd/zaXecz4JxlBVaNkS4j7jRRqGHDopZnmZFHLNdM1a9mPhSFs1SuF7MSTHmJCJfEa9NPdtkwk/fIm62X0zhz2PMi77VxZjDeqSSKy7fxBZzV0mxsv1NMTevN1PMzTj/YhZuEZeeyCK4WnpkWyXhdAlHR8O7VkTkxWRpvJ+jqmdE5EkVm7+KrKDEeT5tj9IiFxGW0axTDLmJXauzydTz0jDENN2MYnFEZLiwk0i5LPM+RNyk11jxNlQk2DruY3lYoh3CWVBndTex2tfWl7hgTFEvc7UE67yaE2yV/1PgZ4r84qr6sGsjEbkQ+A7gZt+GRynkSMQynqFxMo5puyWVg+BY0Ov8vvZEnSox70vEG0342Yage2ZLLCh9mqkQdqj3lfu6YtY+M8NCDZeL7TtfHaNBhaNAOXvmK38m8E0i8gER+SMR+Xsl2/074McB78eEcT77iWTuBjNBFQkxaWdh941YKdB0jsyS9SRa5vRzI9zRVYS4qjZmmftlER94iXjjcmy7FHGTFtkSbVz5bUx83TFVrhhzv+Mi0UX+l+OUCsBGwjM7siWwzpgiWFQbRa2cLyJ3Gu9vUtVVKTYReRfwFMd+ryXT28cBLwD+HvBbIvIMVVVj/+8EHlbVu0TkW3w7NVohh8xPav5jm1bOrhzobCBeG2GIpp/XIehmkigb2+1SPBKZIYuuTIZtRbx2ws+uRLxhWKKdOM2OBrInjdni3kbYXaJuCrqZithMeAY4feeBdmzLV+7JI6p6RdmHqvrSss9E5J8Cb82F+4MisgTOB/7a2OyFwMtE5BrgLOA8Efl1Vf3+qk6N0rWiErGMktIZnfaPWpNktZjrbJpasAB6JhcM270yP1rPJ1Lh8y2iWZwpZA2/MByLtxkr3lXE19ipiKf50jws0Yz4cVZqynPcmIuJr5/dxOVbd1V8yl67XS0+dVlPKl195RN0sfw/wLcCiMgzgQPgEXMDVf1JVb1QVS8mq9/wh3UiDqO1yKPV3bZptIpXuGFDAbPdK3YUBlRbli7MSBfTDWO6E3xE3CnWFrWx4kWbrnNnfNdeKbHMoSJbomGBucS8idXuKgoCbndKwVrxi+XcSrXrZ50H6tlFmtstTQi6BbhFRD4CHAE/pKoqIk8DbjYLMDdlpEIuazMcgY0c3U1pEuHhwnav2DMfS8PqLBfLRgZFQ/DXxLxExH2E28RbxPvCa6JQepwi2DMsETbTEdglAG1xrxL2pqIOm7NMTXeLmVrVTkds+84Dx3RNczslVPUI2LCuVfVBYEPEVfU9wHt82h6pa0VWE4EWJGu+8c4zO5tUvSn6Y7tXTKw6li4Xi2vykIkdsdG7iNv9Xb3eYXhccWzPsESXa8qMBHJlf6xyx3RxwcC6L92Z8MyKbFltG1wsXoQ0t80Y5a1QJWJBvPEolWrCgbS3rJtGrKz1yXSvmBhuBzOixXSxOPtitGNa72VVfKpEvPbm5Jrws0sRN/tQWOawGkgGNiJZCmwxt1MTV1ntppib1npTF4xdAKONdR4s82N2bZWrQjqfdq6VUQo5SGaJmxErRkHiRXxAMv+yV0tl0SNtWLlXTExXix3RYs0ALRukXA3yGX12iXibpwmnq2MMIl5QiDmsnUNYF3OTKmHP9jNm3RrCXuVjLxP2qjJ+sJ7sDMp952VhioFyQkk4f0Yp5CqSX+zpRk3Gtvgmyyrt05kjJJmtu1csAVo7nhEfXdkvI3zR9A3bfe4s4hV5Y3bOarDVGkg2nmxM7KecjZm7hriXiTo0t9btMn5Qbp3XhSkCvV3b+8AurXJdKkdH076xjvJKUolYaMxCBuheGxFP50gyO3avrNqyoj0cVrkLl5vEFH5NkrVZmV4i3qWizxiwxNyOZDGxI5OqhL3KFdPUWjeLbZcV2bZTEftY54FyglXuxyivIkVINSbWZMOX2CZ5VteIFcjF/PAgc68UK003i+VigXWL0itM0LLi10S8rRiPzS9eR82EIXC7qFxJzArKhL2ttW4WjLaLbLexzoOYZzSxyoOYrzPqK8gU8dXMOCnZ2INW7gmDlXulYH4mE/OKcLomg5SmaJ04ES9cVp7n0Xa52OJeJuw+og7V1ro5+7aNdV42EBrYzdR9VSWdB9dK7yyJshSgJcGR5j+6bDCzapp8F1FTQxxllmyKOdROoim7oZii1VjEK10rxvct+jsmChG3xRzWBz8Nd5XT5VJitTcV9aytchdMYaH7Wue+k4gCzQjhiMeM9OoRUo1gmbROBbo5AFbyTy8rvOygcK+s3s/TdTGH8kkuPiGChmit1tnbNMUW8V3R5ObpCEsE9xOMifk/birq4O+CKSz0Muu8S5hiYFwJtabCKK8cVUiXEUmcxXYWCfqTuIfHn44Df6vJQZANgBZiDpWhdF59sWpddu7vWES8CWVPOAVW3L5JmcVe5V9v44Kpqs3qcrVA8zDFwPZQhUVwrfTPkojFMiKNMqvcpM2F3iZZFqyLdi0uq9zlYmlY67IRZd/TFvGh3Ct9RceYYg7r59A+RomwV7lhuljrRSoF2ExD3MY6LxsIPekEq7wZoxRy8uy8a1a5RqQa00l+OgrNcn48OUUOD47DEl1WuSnidcd1iVPZPk1vSk0scdMKXltf7fMfBFvMTcqEfQvWujn7to117humGAg0YZRCrsB8mV3MabQ54tnkrtxH6KELPXO0JuaA29ItFWSPuO+ukSZTcaeUUfbkUCLe27DWXVkrodw67xKmeNLZllWuqhwdTftJaJRJs5YqpIvqOEM7810dXUMPTYrIFdP1sqrtCesJoUyKBFFV1vZq35YX1vzM8bIPzM8cnxfz/BSY59TzfBe55O2c8pDH7ufL2nqrRquZ6MzOKQ/rJfycZfyMbctynZv5zgPTR0SeJyLvF5G7ReROEbmyZLurROTjInJKRF7j07aXkNc1LBm/mH9+j4hcbnz2SRG5t+i8z/EUIV1GzJcx6TIiXfZ4v+lo5S5zwTbDEM3XxwUorOx+deKdOm4EZZhibS/7iP29fIXdZz00EvWy+qxrhaOtYhiwPtXfFHMzm6Ip6AUnXcy3UahZVVnMU6+lIz8H/CtVfR7wuvz9GiISA28ArgYuA14hIpfVNVzrWjEa/jbgNHCHiNymqh81NrsauDRfvg74lfxvwYtVda0SRhXHFeyOSZcRxO3yUzRN/1rHcp4S5T7xwsUCJeGIZfiIdWD9nJqszao1zqXp4x/ABbOaqWvlxXH5zpuGKYLbdx7YZKIDnwqcl79+DPCgY5srgVOq+gCAiLwFuBb4qGPbFT6q6NPwtcAb81p07xeRx4rIU1X1IY/2N1CFo4WQRMIi95HH0ZJ0mXAYHW1MzS38lM5Sah2TZVX20/CPVw58ro6/HfE23TxruWEmRvE9ir9r38U8V01FHVoPmNpJzoCNIiJ24e0+whRPMrtOc9sjrwbeLiK/QOYN+QbHNhcAnzLen2bdKHbic3Z8GnZtcwHwENld6B0iosC/NytOV5EuBGquX3tatf2+rMxaF3Se/ziBaJasu1UwYsvLGqgRa+3++LbR3pTF3MR1bpzWOpRHvMD6ZKO19RXRQtYM07U8OiXWeZ9hihCsc5veXCzNpuifb7mIbzI1TUTeBTzFsd9rgZcA/0JVf1dE/jHwq4BdrNklHQ4fxTo+v3Cfhqu2eaGqPigiTwLeKSIfU9X3bhxE5DrgOoAnPPnppAtWfnLILPIxofM5RY8icgG34s7LRKZOrO2bQxdk22GDPaGOsQib4qa5sb5M3KEipLFC3MGZMmDVVyNrJWzWa+3TOj+pjMgqf0RVryj7UFVtYV4hIm8EXpW//W3gZsdmp4GLjPcX4nbBrOFzZnwaLt0mr0eHqj4sIreSuWo2hDy/q90EcPEzr9B0ISv3indPt8QiF+wiQGzJ+qhxEZZYRe3nTSYjeTAlq9wUcdd5WI1JuAYuq8QdmlnvZeIOa+mK7ayVQ1rngUnzIPDNZHU4vxX4c8c2dwCXisglwKeBlwPfW9ewz6/bp+HbgBty//nXAZ9X1YdE5FFApKpfzF9/O/B/eByTr/wtnHUgpPEoIySBTNDjw4MN69yXOrHu0zKHaYi5S8SL87Aajyg5b2U30DJxh5auGXN/u/8DWOf2QOhJZSirPCv1tpU48v8ZeL2IJMDfknsgRORpwM2qeo2qpiJyA/B2MlvxFlW9r67h2rNS1rCIXJ9/fiNwO1kV6FPAl4Efznd/MnCriBTHerOqvs3nG6cLJV1kg55jYGn9o5fWBIIYkNlsbfanD3VibR+3KXZfxizmtojb56bWzVJivZft19g140pZXNxkyr5TyUAodJ9EFJgWqvrHwNc61j9Ipp/F+9vJNNUbr1+1q+FcwIvXCrzSsd8DwHObdKhgnmYDnunIw2hNQV9zteQDoUVloco26nzm8/aWue32gXGKuc7TtYlWxeuqcxMZ36PUEu/Jeq/0uztqttoVn7qEKUKwzgtG5CsfFaM8IwrM58o8FZIYkhgWeRz52FjO50Sz2Yag264WH8u6TrAXLfzmRV82xBzGkZd8fqZSxF3nRGaz1edluCKKoNo94yvudc+ITa1z29UCzazzk0bfYq6qzM9M+1yOUsgB0lSziXuJ4BF9sxXKhHZprI8Oksx3Xnzmsb9NlWDbLh0fRinmuXXrI+LFWERB1XmsEvkycQd/18zaXIGqxF6UC/rq5t7TJKJAYJRCrgppuiRdRCurfIwUAr4oEddiINTE16quEuxlC1fLqMS8oYibf134iHwxfuGiynqvG5Beq9/q8p/XuFv6mkR00ggulnVGeSZU4ehoyTzN3CppIqt48l1TJShlgm7ja1VXCbbvsUxGIeaeIl6c56pzFR1kl6+PyDcV+Crr3dlOy89t67xLmGKgHUWulSkzSiGHzCKfz5VsPGsckStVLAwfW3yQeFnNPttUCfaihV9vp2JeIeKrZGSWiLvOUVS4TzqIfJXA14l7Yak7c9LXzNytFfT8b1vr/CThSqh1UhmlkK9cK2k24AnUprUdrC81VpkttG3Etc66rmpzcdSzmIO7uEQX0nRDxM0Y8ToRXxylxAdGwe2KG6CvyFcJfJ2414WXOotyN3S3tAlTDLRDVUk7RIaNgVH+97MA/WVulctKzMdCmUi4RDU+SLzcIHU3gCrB7t3NAv2JeS7iZRN9fETc/OuiL5EvE3hb3H0nf3V2t+R/m4YpBk4eo/yvK8rR0YKjoyVJMt6ZnWUsjubEB7M1cfa11LsI9vwrzayKwcW8g4ivBLzivMWHmbD1JfIugbfFvRD11eSvEneLSV+CvnofrPOAxSj/45pfuZl7ZUmaxqviEgvd/qBnXQz4mmBX+bQbuEHK2qkT66bW+SBiXoTjNRDxQkRtEbfPWXxwPKg3tMiXiTuwEV66cf7K/Ocd3S3msUzfucs6X+uvIfaBdXSpzHvObbRtRinkAOl8QZouOTo6jsROdTzWed1AZZmANBHaMtH2aSM94z8ltlcxH0DETR951c2wb5H3GYyuE3SbPqNb6nzngZPDKIU8CwdaZH7yZEm60GFyrpREGLgGOJtMky8EeHb2rLVlXVC2v69Q+25XK+awXoxh40BzbxE3Y8R9RNz86+z7lkS+EPfCUl9N/qpxt7gYyt1iW+eBk8EohRzg6Cjl6GjBWWcfd7HX2p094xIRH7HuYl2nZ+r3TQ4LkavftrWY14h42UQfHxEvO4ezsw1h3oLIx4flN+XVNvlfW2RrwxVbultcxyoI1nkDQhz5MKjCYp6u3Cuw/fBDlyXVNNdJEzdKneVcJdrzL9ffMJLD47GFSuGjoZg7RNxntmaViBfv51+Zb/S1EOaqm+QQIt8krHRb7hZXuKLpbjGt88B+M04hX2allxZ5+aXiZrkYmUVePbC5/lkTn3Vb0U7/1u/GYQpdGa50vBtiXmKJw/qNsKklDm4Rh4p0CMbApY8VX9aW2U62zeZg6+LMfGWht3W39GWdQ7m7paCYSBTYX0RdJet3jIj8NfD/7ejw5wOP7OjYJmPoxxj6AKEfNqEfxzxLVc/t0oCIvI3su/jwiKpe1eV4QzBKId8lInJnVU2+k9SPMfQh9CP0Y+x9GAPj8lUEAoFAoDFByAOBQGDiBCHf5KZddyBnDP0YQx8g9MMm9OOYMfRh5wQfeSAQCEycYJEHAoHAxNl7IReRi0Tk3SJyv4jcJyKvytf/SxH5tIjcnS/XGPv8pIicEpGPi8jfN9Z/rYjcm3/2iyLSaJaSiHwy3/9uEbkzX/d4EXmniPx5/vdxQ/VDRJ5lfN+7ReQLIvLqbZwLEblFRB4WkY8Y63r77iJyKCK/ma//gIhc3KAfPy8iHxORe0TkVhF5bL7+YhH5inFebhy4H739Hzr24zeNPnxSRO4e8nxI+W9069fHZFHVvV6ApwKX56/PBf4MuAz4l8CPOba/DPgwcAhcAvwFEOeffRD4erK5MX8AXN2wL58EzrfW/Rzwmvz1a4CfHbofeRsx8Bng72zjXAAvAi4HPjLEdwf+F+DG/PXLgd9s0I9vB5L89c8a/bjY3M5qZ4h+9PZ/6NIP6/N/DbxuyPNB+W9069fHVJe9t8hV9SFV/VD++ovA/cAFFbtcC7xFVc+o6ieAU8CVIvJU4DxV/RPNroY3At/VQxevBf5j/vo/Gm0O3Y+XAH+hqlUTr3rrg6q+F/ico/2+vrvZ1u8AL3E9Jbj6oarvUNVimuf7gQurvstQ/ahgq+fD+J4C/GPgN6o617UfFb/RrV8fU2Xvhdwkf5x6PvCBfNUN+eP0LcZj2wXAp4zdTufrLshf2+uboMA7ROQuEbkuX/dkVX0IsgsaeNIW+gGZVWL+QLd9LqDf777aJxflzwNPaNGnf0JmyRVcIiJ/KiJ/JCLfZBxrqH709X/o43x8E/BXqvrnxrpBz4f1Gx3j9TFKToyQi8ijgd8FXq2qXwB+Bfgq4HnAQ2SPkODOUaQV65vwQlW9HLgaeKWIvKiqy0P1Q0QOgJcBv52v2sW5qOxii+P2cV5eC6TAm/JVDwFPV9XnA/8r8GYROW/AfvT5f+jjf/QK1m/2g54Px2+0jF2dj9FyIoRcRGZkF8ibVPWtAKr6V6q6UNUl8H8DV+abnwYuMna/EHgwX3+hY703qvpg/vdh4Nb8mH+VPxIWj6gPD90PshvJh1T1r/L+bP1c5PT53Vf7iEgCPAZ/1wUi8kPAdwLflz+Wkz+6fzZ/fReZL/aZQ/Wj5/9D1/ORAP8A+E2jf4OdD9dvlBFdH2Nn74U894P9KnC/qv4bY/1Tjc2+GyhG7W8DXp6Pcl8CXAp8MH+0+6KIvCBv8weB/9ygH48SkXOL12QDbB/Jj/dD+WY/ZLQ5SD9y1iytbZ8Lgz6/u9nWPwT+sBDkOkTkKuAngJep6peN9U8UkTh//Yy8Hw8M2I8+/w+t+5HzUuBjqrpyVQx1Psp+o4zk+pgEfY2ajnUBvpHsEeoe4O58uQb4T8C9+frbgKca+7yWzNr4OEY0BnAF2Y/rL4BfIp9Q5dmPZ5CNtH8YuA94bb7+CcD/C/x5/vfxA/fjHOCzwGOMdYOfC7Ibx0PAnMw6+pE+vztwFpmr6BRZ5MIzGvTjFJn/tLg+iuiG78n/Vx8GPgT8DwP3o7f/Q5d+5Ot/Dbje2naQ80H5b3Tr18dUlzCzMxAIBCbO3rtWAoFAYN8JQh4IBAITJwh5IBAITJwg5IFAIDBxgpAHAoHAxAlCHggEAhMnCHkgEAhMnCDkgUAgMHH+f/L1AWExGHghAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "biv_cov_mat = contri_biv.T @ contri_biv\n",
+    "ind = biv_cov_mat.sum(axis=0).argsort()[-1]\n",
+    "[ind1, ind2] = pureGam.pairwise_idxes_num[ind]\n",
+    "expl_x1 = X_num[:, ind1]\n",
+    "expl_x2 = X_num[:, ind2]\n",
+    "expl_y = contri_biv[:, ind] / sy.scale_\n",
+    "fig = plt.figure()\n",
+    "contour = plt.tricontourf(expl_x1,expl_x2,expl_y, 100, center=0., cmap=\"coolwarm\")\n",
+    "plt.colorbar()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.4 ('sc')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "589acb37ac91c99c4ae72afb74d33f815c06b03e5666438e0937634c624ad4f7"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
The previous `run_pureGam` function has some problems:
1. It uses variables `seed` and `model_output_dir` without defining. The previous code worked because these variables were global variables defined in the context where this function is called. However, when the function is called elsewhere, this is problematic. Now these variables are added as parameters. Future code calling this function needs to input these parameters, together with the parameter `isPureScore`, which no longer has a default value. 
2. It uses `len(y)` to determine `num_epoch`, but `y` is not defined. Changed into `len(y_train)`, which has the correct semantic.

Besides, a demo notebook for running pureGAM and plotting interpretations is added.